### PR TITLE
Add presentation builder plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.4.1",
-  "description": "Claude Code plugins for academic research and development: literature search and review, grant writing and review, manuscript preparation, scientific figures, project lifecycle management, and neuroinformatics",
+  "version": "0.5.0",
+  "description": "Claude Code plugins for academic research and development: literature search and review, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"
@@ -67,6 +67,18 @@
       "source": "./plugins/scientific-figures",
       "category": "research",
       "homepage": "https://github.com/neuromechanist/research-skills"
+    },
+    {
+      "name": "presentation",
+      "description": "Presentation builder: create interactive Reveal.js presentations from JSON with Mermaid diagrams, LaTeX math, code highlighting, and animated reveals",
+      "version": "0.1.0",
+      "author": {
+        "name": "Seyed Yahya Shirazi",
+        "email": "shirazi@ieee.org"
+      },
+      "source": "./plugins/presentation",
+      "category": "research",
+      "homepage": "https://github.com/neuromechanist/agentic-presentation-builder"
     },
     {
       "name": "neuroinformatics",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Research Skills Marketplace
 
 ## Purpose
-Claude Code marketplace providing plugins for academic research workflows and development tooling: literature search and review, grant writing and review, manuscript preparation, scientific figures, project lifecycle management, and neuroinformatics.
+Claude Code marketplace providing plugins for academic research workflows and development tooling: literature search and review, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics.
 
 ## Marketplace Structure
 ```
@@ -31,6 +31,10 @@ research-skills/
 │   ├── scientific-figures/           # Icons + plots + composition + QA
 │   │   ├── .claude-plugin/plugin.json
 │   │   └── skills/scientific-figures/
+│   ├── presentation/                 # Interactive slide decks
+│   │   ├── .claude-plugin/plugin.json
+│   │   ├── commands/create-presentation.md
+│   │   └── skills/presentation-builder/
 │   └── neuroinformatics/             # Neuro data standards + experiments
 │       ├── .claude-plugin/plugin.json
 │       ├── commands/{convert-bids,validate-bids,design-experiment}.md
@@ -46,6 +50,7 @@ research-skills/
 - **manuscript** (v0.2.0): Academic manuscript peer review, writing guidance, and journal-specific formatting for submission
 - **opencite** (v0.2.0): Academic literature search, citation management, PDF retrieval, and literature review synthesis
 - **scientific-figures** (v0.1.1): Publication-quality figures covering icons, plots, composition, and QA
+- **presentation** (v0.1.0): Interactive Reveal.js presentations from JSON via the Agentic Presentation Builder
 - **neuroinformatics** (v0.1.0): Neuroscience data standards (BIDS, HED), experiment design (PsychoPy, LSL), and dataset validation
 
 ## Development

--- a/plugins/presentation/.claude-plugin/plugin.json
+++ b/plugins/presentation/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "presentation",
+  "version": "0.1.0",
+  "description": "Presentation builder: create interactive Reveal.js presentations from JSON using the Agentic Presentation Builder engine",
+  "author": {
+    "name": "Seyed Yahya Shirazi",
+    "email": "shirazi@ieee.org"
+  },
+  "license": "BSD-3-Clause",
+  "keywords": ["presentation", "slides", "revealjs", "json", "mermaid", "katex", "agentic"]
+}

--- a/plugins/presentation/commands/create-presentation.md
+++ b/plugins/presentation/commands/create-presentation.md
@@ -1,0 +1,63 @@
+---
+description: Create an interactive Reveal.js presentation from a topic or outline
+argument-hint: <topic-or-outline> [--theme default|light|dark|academic|minimal] [--slides N]
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# Create Presentation
+
+Create a presentation JSON file using the Agentic Presentation Builder. Load the `presentation:presentation-builder` skill for schema reference and authoring guidance.
+
+## Process
+
+### 1. Understand the Request
+!echo "Topic: $ARGUMENTS"
+
+Determine:
+- Subject matter and audience
+- Approximate number of slides (default: 8-12)
+- Theme preference (default: `academic` for research talks, `default` otherwise)
+- Whether speaker notes are needed
+
+### 2. Locate or Set Up the Builder
+
+Check if the Agentic Presentation Builder is available locally:
+!ls -d ~/Documents/git/casual-vibers/agent-presentation 2>/dev/null || ls -d ./agent-presentation 2>/dev/null || echo "Builder not found locally"
+
+If not found, clone it:
+```bash
+git clone https://github.com/neuromechanist/agentic-presentation-builder.git
+cd agentic-presentation-builder && bun install
+```
+
+### 3. Author the Presentation JSON
+
+Using the schema reference and authoring guide from the skill:
+- Create a `presentation.json` file with proper metadata, slides, and elements
+- Use appropriate layouts (title slide first, two-column for comparisons, single-column for content)
+- Add speaker notes for each slide
+- Use Mermaid diagrams for workflows and architectures
+- Use callouts for key takeaways
+- Keep content density low (advisory warnings flag dense slides)
+
+### 4. Validate
+
+```bash
+bun run validate -- presentation.json --json
+```
+
+Fix any schema errors and address advisory warnings (dense-copy, dense-bullets, missing-image-alt, etc.).
+
+### 5. Serve and Preview
+
+```bash
+bun run dev
+# Open http://localhost:3000/?presentation=./public/presentation.json
+```
+
+### 6. Report
+
+Provide:
+- Path to the generated JSON file
+- Validation summary (errors, warnings)
+- Instructions to view the presentation

--- a/plugins/presentation/commands/create-presentation.md
+++ b/plugins/presentation/commands/create-presentation.md
@@ -43,6 +43,7 @@ Using the schema reference and authoring guide from the skill:
 ### 4. Validate
 
 ```bash
+cd <builder-directory>
 bun run validate -- presentation.json --json
 ```
 
@@ -51,8 +52,9 @@ Fix any schema errors and address advisory warnings (dense-copy, dense-bullets, 
 ### 5. Serve and Preview
 
 ```bash
+cd <builder-directory>
 bun run dev
-# Open http://localhost:3000/?presentation=./public/presentation.json
+# Open http://localhost:3000/?presentation=./presentation.json
 ```
 
 ### 6. Report

--- a/plugins/presentation/skills/presentation-builder/SKILL.md
+++ b/plugins/presentation/skills/presentation-builder/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: presentation-builder
+description: This skill should be used when the user asks to "create a presentation", "make slides", "build a slide deck", "create a talk", "make a keynote", "create a Reveal.js presentation", "generate presentation slides", "make a conference talk", "create a lecture", "build a poster presentation", "create presentation JSON", or mentions presentations, slides, slide decks, Reveal.js, talk preparation, conference presentations, or lecture slides.
+version: 0.1.0
+---
+
+# Presentation Builder
+
+Create interactive Reveal.js presentations from JSON using the [Agentic Presentation Builder](https://github.com/neuromechanist/agentic-presentation-builder). The builder transforms structured JSON definitions into professional, interactive web-based presentations with Mermaid diagrams, LaTeX math, syntax-highlighted code, and animated progressive reveals.
+
+## Pipeline Overview
+
+```
+1. Plan structure  -->  2. Author JSON  -->  3. Validate  -->  4. Serve & present
+   (outline, theme)     (schema-driven)      (CLI validator)    (Vite dev server)
+```
+
+## Prerequisites
+
+The Agentic Presentation Builder must be available locally. Check common locations:
+
+```bash
+ls -d ~/Documents/git/casual-vibers/agent-presentation 2>/dev/null || \
+ls -d ./agent-presentation 2>/dev/null || \
+echo "Not found -- clone from https://github.com/neuromechanist/agentic-presentation-builder"
+```
+
+If not present:
+```bash
+git clone https://github.com/neuromechanist/agentic-presentation-builder.git
+cd agentic-presentation-builder && bun install
+```
+
+## Step 1: Plan the Presentation
+
+Before writing JSON, determine:
+
+- **Topic and audience**: Shapes content depth and vocabulary
+- **Slide count**: 8-12 for a short talk, 15-25 for a full session
+- **Theme**: `academic` for research talks, `default` for general, `dark` for tech demos
+- **Key visuals**: Which slides need Mermaid diagrams, images, code blocks, or tables
+- **Speaker notes**: Include delivery guidance for each slide
+
+## Step 2: Author the Presentation JSON
+
+Write a `presentation.json` following the schema. See `references/schema-reference.md` for the complete field reference and `references/authoring-guide.md` for best practices.
+
+### Minimal structure
+
+```json
+{
+  "presentation": {
+    "metadata": {
+      "title": "My Presentation",
+      "author": "Author Name",
+      "theme": "academic",
+      "aspectRatio": "16:9",
+      "controls": {
+        "slideNumbers": true,
+        "progress": true
+      }
+    },
+    "slides": [
+      {
+        "id": "title",
+        "layout": "title",
+        "elements": [
+          {
+            "type": "text",
+            "content": "# Presentation Title",
+            "style": { "fontSize": "xxl", "alignment": "center" },
+            "position": { "area": "center" }
+          },
+          {
+            "type": "text",
+            "content": "Author Name -- Conference 2026",
+            "style": { "fontSize": "large", "alignment": "center", "color": "#64748B" },
+            "position": { "area": "center", "order": 1 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Slide patterns
+
+**Content slide (single-column):**
+```json
+{
+  "id": "key-findings",
+  "layout": "single-column",
+  "speakerNotes": "Emphasize the 3x improvement in latency.",
+  "elements": [
+    {
+      "type": "text",
+      "content": "## Key Findings",
+      "style": { "fontSize": "xl" },
+      "position": { "area": "header" }
+    },
+    {
+      "type": "bullets",
+      "items": [
+        "**3x reduction** in processing latency",
+        "95% accuracy on held-out test set",
+        "Compatible with existing EEG pipelines"
+      ],
+      "position": { "area": "content" }
+    }
+  ]
+}
+```
+
+**Comparison slide (two-column):**
+```json
+{
+  "id": "comparison",
+  "layout": "two-column",
+  "elements": [
+    {
+      "type": "text",
+      "content": "## Before vs After",
+      "style": { "fontSize": "xl" },
+      "position": { "area": "header" }
+    },
+    {
+      "type": "bullets",
+      "items": ["Manual annotation", "Hours per session", "Inconsistent labels"],
+      "position": { "area": "left" }
+    },
+    {
+      "type": "bullets",
+      "items": ["Automated pipeline", "Minutes per session", "Standardized HED tags"],
+      "position": { "area": "right" }
+    }
+  ]
+}
+```
+
+**Diagram slide (Mermaid):**
+```json
+{
+  "id": "architecture",
+  "layout": "single-column",
+  "elements": [
+    {
+      "type": "text",
+      "content": "## System Architecture",
+      "style": { "fontSize": "xl" },
+      "position": { "area": "header" }
+    },
+    {
+      "type": "mermaid",
+      "diagram": "graph LR\n  A[Raw EEG] --> B[Preprocessing]\n  B --> C[Feature Extraction]\n  C --> D[Classification]\n  D --> E[BCI Output]",
+      "position": { "area": "content" }
+    }
+  ]
+}
+```
+
+**Data slide (table):**
+```json
+{
+  "id": "results",
+  "layout": "single-column",
+  "elements": [
+    {
+      "type": "text",
+      "content": "## Performance Comparison",
+      "style": { "fontSize": "xl" },
+      "position": { "area": "header" }
+    },
+    {
+      "type": "table",
+      "headers": ["Method", "Accuracy", "Latency (ms)", "F1 Score"],
+      "rows": [
+        ["Baseline", "78.2%", "245", "0.76"],
+        ["Our method", "**95.1%**", "82", "**0.94**"],
+        ["State of art", "91.3%", "120", "0.89"]
+      ],
+      "caption": "Table 1: Classification performance across methods",
+      "position": { "area": "content" }
+    }
+  ]
+}
+```
+
+### Element types summary
+
+| Type | Required fields | Key options |
+|------|----------------|-------------|
+| `text` | `type`, `content` | Markdown, LaTeX math, style, animation |
+| `bullets` | `type`, `items` | `bulletStyle`, nested items, animation |
+| `image` | `type`, `src` | `alt`, `width`, `height`, `caption` |
+| `mermaid` | `type`, `diagram` | `theme` (default/dark/forest/neutral) |
+| `callout` | `type`, `content` | `calloutType` (tip/warning/important/note/info), `title` |
+| `code` | `type`, `code` | `language`, `caption`, `lineNumbers` |
+| `table` | `type`, `headers`, `rows` | `caption` |
+
+## Step 3: Validate
+
+Run the CLI validator before serving:
+
+```bash
+cd <builder-directory>
+bun run validate -- path/to/presentation.json --json
+```
+
+The `--json` flag returns structured output with `valid`, `summary.errorCount`, `summary.warningCount`, `errors[]`, and `warnings[]`. Each issue includes `code`, `severity`, `path`, `message`, and `suggestion`.
+
+Fix all schema errors. Address advisory warnings to improve slide quality:
+
+| Warning | Fix |
+|---------|-----|
+| `dense-copy` | Split text across multiple slides |
+| `dense-bullets` | Reduce to 4-6 items or split slide |
+| `dense-media` | Move some media to separate slides |
+| `fixed-image-sizing` | Use percentage widths (e.g., `55%`) instead of `px` |
+| `fragment-overuse` | Reduce animated fragments per slide |
+| `missing-image-alt` | Add `alt` text to all images |
+| `complex-mermaid` | Simplify diagram or split into multiple |
+
+## Step 4: Serve and Present
+
+Copy the JSON file to the builder's `public/` directory (or reference it directly):
+
+```bash
+cd <builder-directory>
+cp path/to/presentation.json public/
+bun run dev
+```
+
+Open in browser: `http://localhost:3000/?presentation=./public/presentation.json`
+
+### Presentation controls
+
+| Key | Action |
+|-----|--------|
+| Arrow keys / Space | Navigate slides |
+| `S` | Speaker notes popup |
+| `O` | Overview (grid view) |
+| `F` | Fullscreen |
+| `P` | Toggle presentation/authoring mode |
+| `?` | Keyboard shortcuts help |
+
+### Delivery modes
+
+- **Authoring mode**: Shows diagnostics, fit overlays, and warnings
+- **Presentation mode**: Clean slide view for delivery
+- **Presenter view**: Speaker notes popup with current/next slide
+- **Audience screen**: Synced external display (open with `?role=audience&mode=presentation`)
+
+## Additional Resources
+
+### Reference files
+- **`references/schema-reference.md`** -- Complete field reference for all element types
+- **`references/authoring-guide.md`** -- Layout patterns, content density guidelines, theme selection, validation workflow
+
+### External documentation
+- [Agentic Presentation Builder repo](https://github.com/neuromechanist/agentic-presentation-builder)
+- [Full documentation site](https://neuromechanist.github.io/agentic-presentation-builder/)
+- [JSON Schema](https://github.com/neuromechanist/agentic-presentation-builder/blob/main/schema/presentation.schema.json)

--- a/plugins/presentation/skills/presentation-builder/SKILL.md
+++ b/plugins/presentation/skills/presentation-builder/SKILL.md
@@ -159,33 +159,6 @@ Write a `presentation.json` following the schema. See `references/schema-referen
 }
 ```
 
-**Data slide (table):**
-```json
-{
-  "id": "results",
-  "layout": "single-column",
-  "elements": [
-    {
-      "type": "text",
-      "content": "## Performance Comparison",
-      "style": { "fontSize": "xl" },
-      "position": { "area": "header" }
-    },
-    {
-      "type": "table",
-      "headers": ["Method", "Accuracy", "Latency (ms)", "F1 Score"],
-      "rows": [
-        ["Baseline", "78.2%", "245", "0.76"],
-        ["Our method", "**95.1%**", "82", "**0.94**"],
-        ["State of art", "91.3%", "120", "0.89"]
-      ],
-      "caption": "Table 1: Classification performance across methods",
-      "position": { "area": "content" }
-    }
-  ]
-}
-```
-
 ### Element types summary
 
 | Type | Required fields | Key options |
@@ -209,17 +182,7 @@ bun run validate -- path/to/presentation.json --json
 
 The `--json` flag returns structured output with `valid`, `summary.errorCount`, `summary.warningCount`, `errors[]`, and `warnings[]`. Each issue includes `code`, `severity`, `path`, `message`, and `suggestion`.
 
-Fix all schema errors. Address advisory warnings to improve slide quality:
-
-| Warning | Fix |
-|---------|-----|
-| `dense-copy` | Split text across multiple slides |
-| `dense-bullets` | Reduce to 4-6 items or split slide |
-| `dense-media` | Move some media to separate slides |
-| `fixed-image-sizing` | Use percentage widths (e.g., `55%`) instead of `px` |
-| `fragment-overuse` | Reduce animated fragments per slide |
-| `missing-image-alt` | Add `alt` text to all images |
-| `complex-mermaid` | Simplify diagram or split into multiple |
+Fix all schema errors. Address advisory warnings to improve slide quality (see `references/authoring-guide.md` for the full list and thresholds).
 
 ## Step 4: Serve and Present
 
@@ -231,25 +194,11 @@ cp path/to/presentation.json public/
 bun run dev
 ```
 
-Open in browser: `http://localhost:3000/?presentation=./public/presentation.json`
+Open in browser: `http://localhost:3000/?presentation=./presentation.json`
 
-### Presentation controls
+Press `P` to toggle between authoring and presentation modes, `S` for speaker notes, `O` for slide overview. See `references/authoring-guide.md` for the full keyboard shortcuts and delivery modes.
 
-| Key | Action |
-|-----|--------|
-| Arrow keys / Space | Navigate slides |
-| `S` | Speaker notes popup |
-| `O` | Overview (grid view) |
-| `F` | Fullscreen |
-| `P` | Toggle presentation/authoring mode |
-| `?` | Keyboard shortcuts help |
-
-### Delivery modes
-
-- **Authoring mode**: Shows diagnostics, fit overlays, and warnings
-- **Presentation mode**: Clean slide view for delivery
-- **Presenter view**: Speaker notes popup with current/next slide
-- **Audience screen**: Synced external display (open with `?role=audience&mode=presentation`)
+To open a synced audience screen, use `?presentation=./presentation.json&role=audience&mode=presentation`.
 
 ## Additional Resources
 

--- a/plugins/presentation/skills/presentation-builder/examples/research-talk.json
+++ b/plugins/presentation/skills/presentation-builder/examples/research-talk.json
@@ -1,0 +1,141 @@
+{
+  "presentation": {
+    "metadata": {
+      "title": "Neural Signal Processing with Real-Time BCI",
+      "author": "Dr. Jane Smith",
+      "description": "A research talk demonstrating the presentation builder's capabilities for academic presentations",
+      "theme": "academic",
+      "aspectRatio": "16:9",
+      "controls": {
+        "slideNumbers": true,
+        "progress": true,
+        "showNotes": false
+      }
+    },
+    "slides": [
+      {
+        "id": "title",
+        "layout": "title",
+        "speakerNotes": "Welcome the audience. Introduce yourself and the lab.",
+        "elements": [
+          {
+            "type": "text",
+            "content": "# Neural Signal Processing with Real-Time BCI",
+            "style": { "fontSize": "xxl", "alignment": "center", "fontWeight": "bold" },
+            "position": { "area": "center" }
+          },
+          {
+            "type": "text",
+            "content": "Dr. Jane Smith -- Neural Engineering Lab\n\nIEEE BCI Conference 2026",
+            "style": { "fontSize": "large", "alignment": "center", "color": "#64748B" },
+            "position": { "area": "center", "order": 1 }
+          }
+        ]
+      },
+      {
+        "id": "motivation",
+        "layout": "single-column",
+        "speakerNotes": "Set up the problem. Emphasize the latency bottleneck in existing systems.",
+        "elements": [
+          {
+            "type": "text",
+            "content": "## Motivation",
+            "style": { "fontSize": "xl" },
+            "position": { "area": "header" }
+          },
+          {
+            "type": "bullets",
+            "items": [
+              "Current BCI systems suffer from **high processing latency**",
+              "Real-time feedback requires sub-100ms response",
+              "Existing pipelines process offline, limiting clinical use",
+              "Need: lightweight, real-time signal processing pipeline"
+            ],
+            "style": { "fontSize": "large" },
+            "position": { "area": "content" }
+          }
+        ]
+      },
+      {
+        "id": "pipeline",
+        "layout": "single-column",
+        "speakerNotes": "Walk through the pipeline left to right. Highlight the LSL integration point.",
+        "elements": [
+          {
+            "type": "text",
+            "content": "## Processing Pipeline",
+            "style": { "fontSize": "xl" },
+            "position": { "area": "header" }
+          },
+          {
+            "type": "mermaid",
+            "diagram": "graph LR\n  A[EEG Amplifier] --> B[LSL Stream]\n  B --> C[Artifact Rejection]\n  C --> D[Feature Extraction]\n  D --> E[Classifier]\n  E --> F[BCI Command]",
+            "position": { "area": "content" }
+          }
+        ]
+      },
+      {
+        "id": "results",
+        "layout": "single-column",
+        "speakerNotes": "Highlight the 3x latency improvement. Note statistical significance.",
+        "elements": [
+          {
+            "type": "text",
+            "content": "## Results",
+            "style": { "fontSize": "xl" },
+            "position": { "area": "header" }
+          },
+          {
+            "type": "table",
+            "headers": ["Method", "Accuracy (%)", "Latency (ms)", "F1 Score"],
+            "rows": [
+              ["Baseline (CSP+LDA)", "78.2", "245", "0.76"],
+              ["Deep ConvNet", "88.7", "156", "0.86"],
+              ["Our method", "**95.1**", "**82**", "**0.94**"]
+            ],
+            "caption": "Table 1: Classification performance on BCI Competition IV Dataset 2a (N=9)",
+            "position": { "area": "content" }
+          },
+          {
+            "type": "callout",
+            "calloutType": "important",
+            "content": "Our method achieves **95.1% accuracy** with **82ms latency**, meeting the real-time threshold for clinical BCI applications.",
+            "position": { "area": "content", "order": 1 }
+          }
+        ]
+      },
+      {
+        "id": "conclusion",
+        "layout": "single-column",
+        "speakerNotes": "Summarize key contributions. Mention the open-source release.",
+        "elements": [
+          {
+            "type": "text",
+            "content": "## Conclusions",
+            "style": { "fontSize": "xl" },
+            "position": { "area": "header" }
+          },
+          {
+            "type": "bullets",
+            "items": [
+              "Real-time BCI pipeline with sub-100ms latency",
+              "State-of-the-art accuracy on standard benchmarks",
+              "Compatible with Lab Streaming Layer (LSL) infrastructure",
+              "Open-source release available on GitHub"
+            ],
+            "style": { "fontSize": "large" },
+            "position": { "area": "content" },
+            "animation": { "type": "fade", "fragment": true }
+          },
+          {
+            "type": "callout",
+            "calloutType": "tip",
+            "title": "Thank You",
+            "content": "Questions? Contact: jane.smith@university.edu",
+            "position": { "area": "content", "order": 1 }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/presentation/skills/presentation-builder/examples/research-talk.json
+++ b/plugins/presentation/skills/presentation-builder/examples/research-talk.json
@@ -8,8 +8,7 @@
       "aspectRatio": "16:9",
       "controls": {
         "slideNumbers": true,
-        "progress": true,
-        "showNotes": false
+        "progress": true
       }
     },
     "slides": [
@@ -106,12 +105,12 @@
       },
       {
         "id": "conclusion",
-        "layout": "single-column",
-        "speakerNotes": "Summarize key contributions. Mention the open-source release.",
+        "layout": "two-column",
+        "speakerNotes": "Summarize key contributions on the left, next steps on the right. Mention the open-source release.",
         "elements": [
           {
             "type": "text",
-            "content": "## Conclusions",
+            "content": "## Conclusions and Next Steps",
             "style": { "fontSize": "xl" },
             "position": { "area": "header" }
           },
@@ -124,15 +123,19 @@
               "Open-source release available on GitHub"
             ],
             "style": { "fontSize": "large" },
-            "position": { "area": "content" },
+            "position": { "area": "left" },
             "animation": { "type": "fade", "fragment": true }
           },
           {
-            "type": "callout",
-            "calloutType": "tip",
-            "title": "Thank You",
-            "content": "Questions? Contact: jane.smith@university.edu",
-            "position": { "area": "content", "order": 1 }
+            "type": "bullets",
+            "items": [
+              "Multi-session transfer learning",
+              "Online adaptation during use",
+              "Clinical trial with 20 participants"
+            ],
+            "bulletStyle": "number",
+            "style": { "fontSize": "large" },
+            "position": { "area": "right" }
           }
         ]
       }

--- a/plugins/presentation/skills/presentation-builder/references/authoring-guide.md
+++ b/plugins/presentation/skills/presentation-builder/references/authoring-guide.md
@@ -1,0 +1,116 @@
+# JSON Authoring Guide
+
+## Top-level structure
+
+Every presentation starts with a `presentation` object containing `metadata` and `slides`:
+
+```json
+{
+  "presentation": {
+    "metadata": {
+      "title": "My Presentation",
+      "theme": "default"
+    },
+    "slides": []
+  }
+}
+```
+
+## Slide structure
+
+Each slide has a `layout` and an `elements` array. Use `position.area` to place elements within the layout.
+
+### Layout types
+
+- **`title`**: Centered content, ideal for title slides and section dividers
+- **`single-column`**: Top-to-bottom flow, the default for most content slides
+- **`two-column`**: Side-by-side layout; use `position.area: "left"` and `"right"` to assign elements
+- **`blank`**: No layout constraints; use absolute positioning
+
+### Position areas by layout
+
+| Layout | Available areas |
+|--------|----------------|
+| `title` | `center` |
+| `single-column` | `header`, `content`, `footer` |
+| `two-column` | `header`, `left`, `right`, `footer` |
+| `blank` | Any (free positioning) |
+
+Use `position.order` to control element ordering within an area (0-based).
+
+## Authoring best practices
+
+### Content density
+- Keep bullet lists to 4-6 items per slide
+- Limit text blocks to 2-3 short paragraphs
+- One Mermaid diagram per slide (complex diagrams need breathing room)
+- The validator flags `dense-copy`, `dense-bullets`, and `dense-media` warnings
+
+### Images
+- Always include `alt` text (validator warns on `missing-image-alt`)
+- Prefer percentage widths (`55%`) over fixed pixels for responsive sizing (validator warns on `fixed-image-sizing`)
+- Place images in the `public/assets/` directory of the builder project
+
+### Mermaid diagrams
+- Keep diagrams simple; deeply nested graphs are flagged as `complex-mermaid`
+- Test rendering at presentation resolution (1920x1080)
+- Use the diagram's `theme` property to match the presentation theme
+
+### Animations and fragments
+- Use `animation.fragment: true` for progressive reveal
+- Set `animation.index` to control reveal order
+- Keep fragment counts low per slide (flagged as `fragment-overuse` if excessive)
+- Good use case: revealing bullet points one at a time
+- Bad use case: animating every element on a dense slide
+
+### Speaker notes
+- Use `speakerNotes` for delivery guidance, not content
+- Press `S` during presentation to view notes
+- Notes support plain text
+
+### Themes
+- `default`: Blue primary, clean and professional
+- `light`: Bright, high-contrast
+- `dark`: Dark background, light text
+- `academic`: Serif-influenced, formal (good for research talks)
+- `minimal`: Stripped-down, content-focused
+
+For custom branding, use `customTheme.colors` and `customTheme.fonts` in metadata.
+
+## Validation workflow
+
+1. Write or edit the JSON file
+2. Run structured validation:
+   ```bash
+   bun run validate -- path/to/presentation.json --json
+   ```
+3. Fix schema errors (blocking) and advisory warnings (quality)
+4. Serve and visually inspect:
+   ```bash
+   bun run dev
+   # Open http://localhost:3000/?presentation=./public/presentation.json
+   ```
+
+### Advisory warnings
+
+| Warning | Meaning |
+|---------|---------|
+| `dense-copy` | Too much text on a slide |
+| `dense-bullets` | Too many bullet items |
+| `dense-media` | Too many media elements |
+| `fixed-image-sizing` | Use percentage widths instead of px |
+| `fragment-overuse` | Too many animated fragments |
+| `missing-image-alt` | Image lacks alt text |
+| `complex-mermaid` | Mermaid diagram is overly complex |
+
+## Keyboard shortcuts (during presentation)
+
+| Key | Action |
+|-----|--------|
+| `,` | Open settings |
+| `P` | Toggle presentation mode |
+| `S` | Open speaker notes |
+| `O` | Overview (grid view) |
+| `F` | Fullscreen |
+| `?` | Keyboard shortcuts help |
+| `Esc` | Close overlays |

--- a/plugins/presentation/skills/presentation-builder/references/authoring-guide.md
+++ b/plugins/presentation/skills/presentation-builder/references/authoring-guide.md
@@ -1,21 +1,5 @@
 # JSON Authoring Guide
 
-## Top-level structure
-
-Every presentation starts with a `presentation` object containing `metadata` and `slides`:
-
-```json
-{
-  "presentation": {
-    "metadata": {
-      "title": "My Presentation",
-      "theme": "default"
-    },
-    "slides": []
-  }
-}
-```
-
 ## Slide structure
 
 Each slide has a `layout` and an `elements` array. Use `position.area` to place elements within the layout.
@@ -36,19 +20,21 @@ Each slide has a `layout` and an `elements` array. Use `position.area` to place 
 | `two-column` | `header`, `left`, `right`, `footer` |
 | `blank` | Any (free positioning) |
 
+These are recommended area assignments. The schema allows any area value, but elements placed in non-standard areas for a layout may not render as expected.
+
 Use `position.order` to control element ordering within an area (0-based).
 
 ## Authoring best practices
 
 ### Content density
-- Keep bullet lists to 4-6 items per slide
+- Keep bullet lists to 6 or fewer items per slide (the validator fires `dense-bullets` at >6)
 - Limit text blocks to 2-3 short paragraphs
 - One Mermaid diagram per slide (complex diagrams need breathing room)
 - The validator flags `dense-copy`, `dense-bullets`, and `dense-media` warnings
 
 ### Images
 - Always include `alt` text (validator warns on `missing-image-alt`)
-- Prefer percentage widths (`55%`) over fixed pixels for responsive sizing (validator warns on `fixed-image-sizing`)
+- Prefer percentage widths (`55%`) over fixed pixels for responsive sizing (validator warns `fixed-image-sizing` when a slide has multiple media elements and any image uses fixed pixel sizing)
 - Place images in the `public/assets/` directory of the builder project
 
 ### Mermaid diagrams
@@ -66,7 +52,7 @@ Use `position.order` to control element ordering within an area (0-based).
 ### Speaker notes
 - Use `speakerNotes` for delivery guidance, not content
 - Press `S` during presentation to view notes
-- Notes support plain text
+- Notes support plain text and basic markdown
 
 ### Themes
 - `default`: Blue primary, clean and professional
@@ -88,7 +74,7 @@ For custom branding, use `customTheme.colors` and `customTheme.fonts` in metadat
 4. Serve and visually inspect:
    ```bash
    bun run dev
-   # Open http://localhost:3000/?presentation=./public/presentation.json
+   # Open http://localhost:3000/?presentation=./presentation.json
    ```
 
 ### Advisory warnings
@@ -96,9 +82,9 @@ For custom branding, use `customTheme.colors` and `customTheme.fonts` in metadat
 | Warning | Meaning |
 |---------|---------|
 | `dense-copy` | Too much text on a slide |
-| `dense-bullets` | Too many bullet items |
+| `dense-bullets` | More than 6 bullet items on a slide |
 | `dense-media` | Too many media elements |
-| `fixed-image-sizing` | Use percentage widths instead of px |
+| `fixed-image-sizing` | Fixed pixel image sizing on a slide with multiple media |
 | `fragment-overuse` | Too many animated fragments |
 | `missing-image-alt` | Image lacks alt text |
 | `complex-mermaid` | Mermaid diagram is overly complex |
@@ -114,3 +100,6 @@ For custom branding, use `customTheme.colors` and `customTheme.fonts` in metadat
 | `F` | Fullscreen |
 | `?` | Keyboard shortcuts help |
 | `Esc` | Close overlays |
+| `Home` / `End` | Jump to first / last slide |
+| `B` / `.` | Blackout screen |
+| Arrow keys / Space | Navigate slides |

--- a/plugins/presentation/skills/presentation-builder/references/schema-reference.md
+++ b/plugins/presentation/skills/presentation-builder/references/schema-reference.md
@@ -14,8 +14,12 @@ The source of truth is `schema/presentation.schema.json` in the Agentic Presenta
 | `controls.slideNumbers` | `boolean` | Slide number visibility |
 | `controls.progress` | `boolean` | Progress bar visibility |
 | `controls.showNotes` | `boolean` | Enables speaker notes support |
-| `customTheme.colors.*` | `string` | Hex colors only |
-| `customTheme.fonts.*` | `string` | CSS font-family values |
+| `customTheme.colors.primary` | `string` | Primary color (hex) |
+| `customTheme.colors.background` | `string` | Background color (hex) |
+| `customTheme.colors.text` | `string` | Text color (hex) |
+| `customTheme.colors.accent` | `string` | Accent color (hex) |
+| `customTheme.fonts.heading` | `string` | Heading font (CSS font-family) |
+| `customTheme.fonts.body` | `string` | Body font (CSS font-family) |
 
 ## Slide fields
 

--- a/plugins/presentation/skills/presentation-builder/references/schema-reference.md
+++ b/plugins/presentation/skills/presentation-builder/references/schema-reference.md
@@ -1,0 +1,105 @@
+# Schema Reference
+
+The source of truth is `schema/presentation.schema.json` in the Agentic Presentation Builder repository.
+
+## Presentation metadata
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `title` | `string` | Required |
+| `author` | `string` | Optional |
+| `description` | `string` | Optional |
+| `theme` | `string` | `default`, `light`, `dark`, `academic`, `minimal` |
+| `aspectRatio` | `string` | `16:9` or `4:3` |
+| `controls.slideNumbers` | `boolean` | Slide number visibility |
+| `controls.progress` | `boolean` | Progress bar visibility |
+| `controls.showNotes` | `boolean` | Enables speaker notes support |
+| `customTheme.colors.*` | `string` | Hex colors only |
+| `customTheme.fonts.*` | `string` | CSS font-family values |
+
+## Slide fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | `string` | Stable slide identifier |
+| `title` | `string` | Overview label |
+| `layout` | `string` | `single-column`, `two-column`, `title`, `blank` |
+| `background` | `string` | Hex color or image path |
+| `transition` | `string` | `slide`, `fade`, `convex`, `concave`, `zoom` |
+| `speakerNotes` | `string` | Presenter notes |
+| `elements` | `array` | Slide content |
+
+## Shared element fields
+
+### `style`
+
+| Field | Type | Allowed values |
+| --- | --- | --- |
+| `fontSize` | `string` | `small`, `medium`, `large`, `xl`, `xxl` |
+| `alignment` | `string` | `left`, `center`, `right`, `justify` |
+| `color` | `string` | Hex color |
+| `fontWeight` | `string` | `normal`, `bold`, `light` |
+
+### `position`
+
+| Field | Type | Allowed values |
+| --- | --- | --- |
+| `area` | `string` | `header`, `content`, `footer`, `left`, `right`, `center` |
+| `order` | `integer` | `0` or greater |
+
+### `animation`
+
+| Field | Type | Allowed values |
+| --- | --- | --- |
+| `type` | `string` | `fade`, `slide-up`, `slide-down`, `zoom`, `none` |
+| `fragment` | `boolean` | Progressive reveal toggle |
+| `index` | `integer` | Reveal order |
+
+## Element types
+
+### `text`
+
+- Required: `type`, `content`
+- Supports Markdown, GitHub-style alerts (`> [!TIP]`), and inline/display LaTeX math
+- Use for headings (`# Title`), prose, and formatted text
+
+### `bullets`
+
+- Required: `type`, `items`
+- `bulletStyle`: `disc`, `circle`, `square`, `number`, `none`
+- Items can be plain strings or nested `{ text, children }` objects
+- Each item supports Markdown
+
+### `image`
+
+- Required: `type`, `src`
+- Optional: `alt`, `width`, `height`, `caption`
+- Width and height support `%`, `px`, or `auto`
+- Prefer percentage widths (e.g., `55%`) for responsive sizing
+- Always include `alt` text
+
+### `mermaid`
+
+- Required: `type`, `diagram`
+- `theme`: `default`, `dark`, `forest`, `neutral`
+- Supports flowcharts, sequence diagrams, class diagrams, state diagrams, etc.
+
+### `callout`
+
+- Required: `type`, `content`
+- `calloutType`: `tip`, `warning`, `important`, `note`, `info`
+- Optional `title`
+- Content supports Markdown
+
+### `code`
+
+- Required: `type`, `code`
+- Optional: `language` (default: `javascript`), `caption`, `lineNumbers` (default: `true`)
+- Supports: javascript, python, java, go, rust, typescript, html, css, json, and more
+
+### `table`
+
+- Required: `type`, `headers`, `rows`
+- `headers`: array of strings
+- `rows`: array of arrays of strings
+- Optional `caption`


### PR DESCRIPTION
## Summary

- Add new `presentation` plugin integrating the [Agentic Presentation Builder](https://github.com/neuromechanist/agentic-presentation-builder) v0.1.0
- Skill teaches Claude the JSON schema, slide patterns, validation workflow, and serving
- `/create-presentation` command for end-to-end presentation authoring
- Marketplace bumped to v0.5.0

## Changes

- `plugins/presentation/.claude-plugin/plugin.json` -- plugin manifest
- `plugins/presentation/commands/create-presentation.md` -- slash command
- `plugins/presentation/skills/presentation-builder/SKILL.md` -- main skill with schema, patterns, validation
- `plugins/presentation/skills/presentation-builder/references/schema-reference.md` -- complete field reference
- `plugins/presentation/skills/presentation-builder/references/authoring-guide.md` -- layout, themes, density guidelines
- `plugins/presentation/skills/presentation-builder/examples/research-talk.json` -- working BCI research talk example
- `.claude-plugin/marketplace.json` -- added presentation plugin, bumped to v0.5.0
- `CLAUDE.md` -- updated structure and plugin list

## Test plan

- [x] Plugin directory follows marketplace conventions (matches scientific-figures, neuroinformatics patterns)
- [x] SKILL.md covers full workflow: plan, author, validate, serve
- [x] Example JSON is valid against the builder's schema
- [x] marketplace.json is valid JSON with correct source path
- [x] CLAUDE.md structure tree matches actual directory layout

Closes #17