### PR TITLE
Add update-rules skill and command to project plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Claude Code plugins for academic research and development: literature search and review, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "project",
-      "description": "Project lifecycle toolkit: initialization, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
-      "version": "0.2.1",
+      "description": "Project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
+      "version": "0.2.2",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ research-skills/
 ├── plugins/
 │   ├── project/                      # Project lifecycle toolkit
 │   │   ├── .claude-plugin/plugin.json
-│   │   ├── commands/{init-project,epic-dev,epic-status,setup-ci,release-prep,doc-process}.md
-│   │   ├── skills/{init-project,workflow-reference,ci-scaffolding,docker-packaging,security-audit,document-processing}/
+│   │   ├── commands/{init-project,update-rules,epic-dev,epic-status,setup-ci,release-prep,doc-process}.md
+│   │   ├── skills/{init-project,update-rules,workflow-reference,ci-scaffolding,docker-packaging,security-audit,document-processing}/
 │   │   ├── agents/{dependency-auditor,release-prep}.md
 │   │   ├── templates/               # Claude, Cursor, context, config, CI/CD
 │   │   └── scripts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ research-skills/
 ```
 
 ## Plugins
-- **project** (v0.2.0): Project lifecycle toolkit with initialization, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing
+- **project** (v0.2.2): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing
 - **grant** (v0.2.0): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance
 - **manuscript** (v0.2.0): Academic manuscript peer review, writing guidance, and journal-specific formatting for submission
 - **opencite** (v0.2.0): Academic literature search, citation management, PDF retrieval, and literature review synthesis

--- a/plugins/project/.claude-plugin/plugin.json
+++ b/plugins/project/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project",
-  "version": "0.2.1",
-  "description": "Complete project lifecycle toolkit: initialization, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
+  "version": "0.2.2",
+  "description": "Complete project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"

--- a/plugins/project/bin/project-diff-rules
+++ b/plugins/project/bin/project-diff-rules
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Compare existing rules/config against plugin templates.
+# Outputs structured KEY=VALUE pairs for consumption by the update-rules command.
+#
+# Usage: project-diff-rules <user|project> [target-dir]
+#   project: compares ./CLAUDE.md + .rules/ against templates
+#   user:    compares ~/.claude/CLAUDE.md against template best practices
+set -euo pipefail
+
+TEMPLATES_DIR="$(project-templates-path)" || exit 1
+LEVEL="${1:-}"
+
+if [ -z "$LEVEL" ]; then
+    echo "ERROR=No level specified. Use 'user' or 'project'." >&2
+    exit 1
+fi
+
+case "$LEVEL" in
+    project)
+        TARGET_DIR="${2:-.}"
+
+        if [ ! -d "$TARGET_DIR" ]; then
+            echo "ERROR=Target directory '$TARGET_DIR' does not exist" >&2
+            exit 1
+        fi
+
+        # --- Rules directory status ---
+        if [ -d "$TARGET_DIR/.rules" ]; then
+            echo "HAS_RULES_DIR=true"
+        else
+            echo "HAS_RULES_DIR=false"
+        fi
+
+        # --- CLAUDE.md status ---
+        if [ -f "$TARGET_DIR/CLAUDE.md" ]; then
+            echo "HAS_CLAUDE_MD=true"
+        else
+            echo "HAS_CLAUDE_MD=false"
+        fi
+
+        # --- Rules comparison ---
+        for template_rule in "$TEMPLATES_DIR/claude/rules/"*.md; do
+            basename="$(basename "$template_rule")"
+            target_rule="$TARGET_DIR/.rules/$basename"
+
+            if [ ! -f "$target_rule" ]; then
+                echo "RULE_MISSING=$basename"
+            elif diff -q "$template_rule" "$target_rule" >/dev/null 2>&1; then
+                echo "RULE_CURRENT=$basename"
+            else
+                echo "RULE_CHANGED=$basename"
+            fi
+        done
+
+        # --- Custom rules (user-added, not in templates) ---
+        if [ -d "$TARGET_DIR/.rules" ]; then
+            for existing_rule in "$TARGET_DIR/.rules/"*.md; do
+                [ -f "$existing_rule" ] || continue
+                basename="$(basename "$existing_rule")"
+                if [ ! -f "$TEMPLATES_DIR/claude/rules/$basename" ]; then
+                    echo "RULE_CUSTOM=$basename"
+                fi
+            done
+        fi
+
+        # --- CLAUDE.md section headers ---
+        if [ -f "$TARGET_DIR/CLAUDE.md" ]; then
+            grep -n '^## ' "$TARGET_DIR/CLAUDE.md" | while IFS= read -r line; do
+                echo "PROJECT_SECTION=$line"
+            done
+        fi
+
+        # --- Template CLAUDE.md section headers ---
+        grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" | while IFS= read -r line; do
+            echo "TEMPLATE_SECTION=$line"
+        done
+        ;;
+
+    user)
+        USER_CLAUDE="${2:-$HOME/.claude/CLAUDE.md}"
+
+        if [ ! -f "$USER_CLAUDE" ]; then
+            echo "ERROR=User CLAUDE.md not found at $USER_CLAUDE" >&2
+            exit 1
+        fi
+
+        echo "HAS_USER_CLAUDE=true"
+        echo "USER_CLAUDE_PATH=$USER_CLAUDE"
+
+        # --- User CLAUDE.md section headers ---
+        grep -n '^## ' "$USER_CLAUDE" | while IFS= read -r line; do
+            echo "USER_SECTION=$line"
+        done
+
+        # --- Template CLAUDE.md section headers ---
+        grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" | while IFS= read -r line; do
+            echo "TEMPLATE_SECTION=$line"
+        done
+
+        # --- Template rules list (for best-practice suggestions) ---
+        for template_rule in "$TEMPLATES_DIR/claude/rules/"*.md; do
+            basename="$(basename "$template_rule")"
+            echo "TEMPLATE_RULE=$basename"
+        done
+        ;;
+
+    *)
+        echo "ERROR=Invalid level '$LEVEL'. Use 'user' or 'project'." >&2
+        exit 1
+        ;;
+esac

--- a/plugins/project/bin/project-diff-rules
+++ b/plugins/project/bin/project-diff-rules
@@ -3,15 +3,47 @@
 # Outputs structured KEY=VALUE pairs for consumption by the update-rules command.
 #
 # Usage: project-diff-rules <user|project> [target-dir]
-#   project: compares ./CLAUDE.md + .rules/ against templates
-#   user:    compares ~/.claude/CLAUDE.md against template best practices
+#   project: compares ./CLAUDE.md + .rules/ against templates and lists template rules
+#   user:    compares ~/.claude/CLAUDE.md against template sections and lists template rules
+#
+# Output keys (project level):
+#   HAS_RULES_DIR=true|false
+#   HAS_CLAUDE_MD=true|false
+#   RULE_MISSING=<filename>     -- template rule not found in project
+#   RULE_CURRENT=<filename>     -- rule matches template exactly
+#   RULE_CHANGED=<filename>     -- rule differs from template
+#   RULE_CUSTOM=<filename>      -- user rule not in templates
+#   PROJECT_SECTION=<line>      -- H2 header from project CLAUDE.md
+#   TEMPLATE_SECTION=<line>     -- H2 header from template CLAUDE.md
+#
+# Output keys (user level):
+#   HAS_USER_CLAUDE=true
+#   USER_CLAUDE_PATH=<path>
+#   USER_SECTION=<line>         -- H2 header from user CLAUDE.md
+#   TEMPLATE_SECTION=<line>     -- H2 header from template CLAUDE.md
+#   TEMPLATE_RULE=<filename>    -- available template rule file
+#
+# Emits STATUS=complete as the final line on success.
 set -euo pipefail
 
-TEMPLATES_DIR="$(project-templates-path)" || exit 1
+TEMPLATES_DIR="$(project-templates-path)" || {
+    echo "ERROR: Failed to resolve templates directory" >&2
+    exit 1
+}
 LEVEL="${1:-}"
 
 if [ -z "$LEVEL" ]; then
-    echo "ERROR=No level specified. Use 'user' or 'project'." >&2
+    echo "ERROR: No level specified. Use 'user' or 'project'." >&2
+    exit 1
+fi
+
+# Validate template structure
+if [ ! -f "$TEMPLATES_DIR/claude/CLAUDE.md" ]; then
+    echo "ERROR: Template CLAUDE.md not found at $TEMPLATES_DIR/claude/CLAUDE.md" >&2
+    exit 1
+fi
+if [ ! -d "$TEMPLATES_DIR/claude/rules" ]; then
+    echo "ERROR: Template rules directory not found at $TEMPLATES_DIR/claude/rules/" >&2
     exit 1
 fi
 
@@ -20,7 +52,7 @@ case "$LEVEL" in
         TARGET_DIR="${2:-.}"
 
         if [ ! -d "$TARGET_DIR" ]; then
-            echo "ERROR=Target directory '$TARGET_DIR' does not exist" >&2
+            echo "ERROR: Target directory '$TARGET_DIR' does not exist" >&2
             exit 1
         fi
 
@@ -40,15 +72,23 @@ case "$LEVEL" in
 
         # --- Rules comparison ---
         for template_rule in "$TEMPLATES_DIR/claude/rules/"*.md; do
-            basename="$(basename "$template_rule")"
-            target_rule="$TARGET_DIR/.rules/$basename"
+            [ -f "$template_rule" ] || continue
+            rule_name="$(basename "$template_rule")"
+            target_rule="$TARGET_DIR/.rules/$rule_name"
 
             if [ ! -f "$target_rule" ]; then
-                echo "RULE_MISSING=$basename"
-            elif diff -q "$template_rule" "$target_rule" >/dev/null 2>&1; then
-                echo "RULE_CURRENT=$basename"
+                echo "RULE_MISSING=$rule_name"
             else
-                echo "RULE_CHANGED=$basename"
+                diff_status=0
+                diff -q "$template_rule" "$target_rule" >/dev/null 2>&1 || diff_status=$?
+                if [ "$diff_status" -eq 0 ]; then
+                    echo "RULE_CURRENT=$rule_name"
+                elif [ "$diff_status" -eq 1 ]; then
+                    echo "RULE_CHANGED=$rule_name"
+                else
+                    echo "ERROR: Failed to compare rule '$rule_name'" >&2
+                    exit 1
+                fi
             fi
         done
 
@@ -56,31 +96,31 @@ case "$LEVEL" in
         if [ -d "$TARGET_DIR/.rules" ]; then
             for existing_rule in "$TARGET_DIR/.rules/"*.md; do
                 [ -f "$existing_rule" ] || continue
-                basename="$(basename "$existing_rule")"
-                if [ ! -f "$TEMPLATES_DIR/claude/rules/$basename" ]; then
-                    echo "RULE_CUSTOM=$basename"
+                rule_name="$(basename "$existing_rule")"
+                if [ ! -f "$TEMPLATES_DIR/claude/rules/$rule_name" ]; then
+                    echo "RULE_CUSTOM=$rule_name"
                 fi
             done
         fi
 
         # --- CLAUDE.md section headers ---
         if [ -f "$TARGET_DIR/CLAUDE.md" ]; then
-            grep -n '^## ' "$TARGET_DIR/CLAUDE.md" | while IFS= read -r line; do
+            while IFS= read -r line; do
                 echo "PROJECT_SECTION=$line"
-            done
+            done < <(grep -n '^## ' "$TARGET_DIR/CLAUDE.md" || true)
         fi
 
         # --- Template CLAUDE.md section headers ---
-        grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" | while IFS= read -r line; do
+        while IFS= read -r line; do
             echo "TEMPLATE_SECTION=$line"
-        done
+        done < <(grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" || true)
         ;;
 
     user)
         USER_CLAUDE="${2:-$HOME/.claude/CLAUDE.md}"
 
         if [ ! -f "$USER_CLAUDE" ]; then
-            echo "ERROR=User CLAUDE.md not found at $USER_CLAUDE" >&2
+            echo "ERROR: User CLAUDE.md not found at $USER_CLAUDE" >&2
             exit 1
         fi
 
@@ -88,24 +128,27 @@ case "$LEVEL" in
         echo "USER_CLAUDE_PATH=$USER_CLAUDE"
 
         # --- User CLAUDE.md section headers ---
-        grep -n '^## ' "$USER_CLAUDE" | while IFS= read -r line; do
+        while IFS= read -r line; do
             echo "USER_SECTION=$line"
-        done
+        done < <(grep -n '^## ' "$USER_CLAUDE" || true)
 
         # --- Template CLAUDE.md section headers ---
-        grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" | while IFS= read -r line; do
+        while IFS= read -r line; do
             echo "TEMPLATE_SECTION=$line"
-        done
+        done < <(grep -n '^## ' "$TEMPLATES_DIR/claude/CLAUDE.md" || true)
 
         # --- Template rules list (for best-practice suggestions) ---
         for template_rule in "$TEMPLATES_DIR/claude/rules/"*.md; do
-            basename="$(basename "$template_rule")"
-            echo "TEMPLATE_RULE=$basename"
+            [ -f "$template_rule" ] || continue
+            rule_name="$(basename "$template_rule")"
+            echo "TEMPLATE_RULE=$rule_name"
         done
         ;;
 
     *)
-        echo "ERROR=Invalid level '$LEVEL'. Use 'user' or 'project'." >&2
+        echo "ERROR: Invalid level '$LEVEL'. Use 'user' or 'project'." >&2
         exit 1
         ;;
 esac
+
+echo "STATUS=complete"

--- a/plugins/project/commands/update-rules.md
+++ b/plugins/project/commands/update-rules.md
@@ -21,15 +21,14 @@ If `$ARGUMENTS` is empty or not one of `user`/`project`, ask the user which leve
 ### 2. Run Comparison
 !project-diff-rules $ARGUMENTS
 
-If the above command failed, report the exact error to the user and stop. Do not proceed with remaining steps.
+If the above command failed or the output does not contain `STATUS=complete` as the final line, the script terminated prematurely. Report the error to the user and stop. Do not proceed with remaining steps.
 
 ### 3. Analyze Results
 
 #### For PROJECT level:
 
 **Missing rules (RULE_MISSING):**
-- Read the missing rule file from templates to understand its purpose:
-  !cat "$(project-templates-path)/claude/rules/<filename>" | head -20
+- Read the first 20 lines of the missing rule file from templates to understand its purpose
 - Determine if the rule is relevant to this project (e.g., skip python.md for a JS-only project)
 - Present each missing rule with a brief description and ask which to add
 

--- a/plugins/project/commands/update-rules.md
+++ b/plugins/project/commands/update-rules.md
@@ -1,0 +1,92 @@
+---
+description: Update CLAUDE.md and .rules/ from latest templates
+argument-hint: <user|project>
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# Update Rules and Configuration
+
+Update existing CLAUDE.md and .rules/ files from the latest plugin templates without overwriting user customizations. Load the `project:update-rules` skill for the full comparison strategy and non-destructive guarantees.
+
+## Setup Process:
+
+### 1. Parse Arguments
+
+Determine the level from `$ARGUMENTS`:
+- `user` -> update `~/.claude/CLAUDE.md`
+- `project` -> update `./CLAUDE.md` + `.rules/`
+
+If `$ARGUMENTS` is empty or not one of `user`/`project`, ask the user which level to update.
+
+### 2. Run Comparison
+!project-diff-rules $ARGUMENTS
+
+If the above command failed, report the exact error to the user and stop. Do not proceed with remaining steps.
+
+### 3. Analyze Results
+
+#### For PROJECT level:
+
+**Missing rules (RULE_MISSING):**
+- Read the missing rule file from templates to understand its purpose:
+  !cat "$(project-templates-path)/claude/rules/<filename>" | head -20
+- Determine if the rule is relevant to this project (e.g., skip python.md for a JS-only project)
+- Present each missing rule with a brief description and ask which to add
+
+**Changed rules (RULE_CHANGED):**
+- For each changed rule, show a unified diff:
+  !diff --unified "$(project-templates-path)/claude/rules/<filename>" ".rules/<filename>"
+- Analyze: are the differences template improvements or user customizations?
+- Present options: (a) accept template version, (b) merge specific changes, (c) skip
+
+**Current rules (RULE_CURRENT):**
+- Report as up to date (no action needed)
+
+**Custom rules (RULE_CUSTOM):**
+- Report as user-created (preserved, no action needed)
+
+**CLAUDE.md section comparison:**
+- Read both CLAUDE.md files in full
+- Compare H2 sections: identify sections in template missing from project
+- For matching sections, compare content for improvements
+- Respect project-specific content (replaced placeholders, architecture maps, custom guidelines)
+
+#### For USER level:
+
+**Section comparison:**
+- Read `~/.claude/CLAUDE.md` in full
+- Read template CLAUDE.md for best-practice content
+- Use `references/section-mapping.md` to map template sections to user sections
+- Read relevant template rules (testing.md, git.md) for universally applicable best practices
+
+**Item-by-item checks:**
+- Compare `[NEVER DO THIS]` lists item-by-item; suggest missing entries
+- Check tool recommendations match (UV, Bun, ruff, ty, biome)
+- Check workflow steps for new best practices
+- Identify template sections with no equivalent in user config
+
+### 4. Present Update Plan
+
+Show a numbered list of proposed changes:
+- `[ADD]` - New content to add (new rules, new sections, new list items)
+- `[UPDATE]` - Existing content to modify (improved wording, new steps)
+- `[INFO]` - Already current, no change needed
+
+For each `[ADD]` or `[UPDATE]`, show a preview of the change.
+
+If everything is current, report "All rules and configuration are up to date." and stop.
+
+Ask the user which changes to apply. Never apply without confirmation.
+
+### 5. Apply Approved Changes
+
+For each approved change:
+- **New .rules/ files:** use Write to create them
+- **Existing .rules/ files:** use Edit for surgical modifications, or Write if accepting full template version
+- **CLAUDE.md sections:** use Edit to insert or update specific sections
+- **New list items:** use Edit to append to existing lists
+
+### 6. Verify
+!project-diff-rules $ARGUMENTS
+
+Confirm that approved changes were applied. Report final status.

--- a/plugins/project/skills/update-rules/SKILL.md
+++ b/plugins/project/skills/update-rules/SKILL.md
@@ -80,7 +80,7 @@ Show preview of what will change for each item. Ask user to confirm which change
 
 ### Step 4: Apply Approved Changes
 
-- For existing files: use Edit tool for surgical modifications. Never use Write to overwrite.
+- For existing files: use Edit tool for surgical modifications. Use Write only when the user explicitly approves replacing a file with the template version.
 - For new .rules/ files: use Write to create them (safe, creating new file).
 - For CLAUDE.md sections: use Edit to insert or update specific sections.
 
@@ -93,7 +93,7 @@ Run `project-diff-rules <level>` again to confirm all approved changes were appl
 - NEVER overwrite a file without showing the diff first
 - NEVER remove user-added content (custom rules, custom sections, custom guidelines)
 - NEVER replace project-specific values (project name, tech stack, architecture) with template placeholders
-- ALWAYS use Edit for existing files, never Write (except for brand-new rule files)
+- ALWAYS use Edit for existing files when merging selective changes. Write is acceptable only for new rule files or when the user explicitly approves replacing a file with the template version.
 - For changed .rules/ files, present three options: (a) accept template version, (b) merge specific changes, (c) skip
 
 ## Distinguishing Template Improvements from User Customizations

--- a/plugins/project/skills/update-rules/SKILL.md
+++ b/plugins/project/skills/update-rules/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: update-rules
+description: "This skill should be used when the user asks to \"update rules\", \"sync rules\", \"update CLAUDE.md\", \"refresh rules\", \"update project config\", \"sync templates\", \"update vibe rules\", \"check for rule updates\", \"update user rules\", \"update global config\", \"refresh CLAUDE.md\", \"sync .rules directory\", \"what's new in templates\", or wants to update existing Claude/rules configuration from the latest templates without overwriting customizations."
+version: 0.1.0
+---
+
+# Update Rules and Configuration
+
+Update existing CLAUDE.md and .rules/ files from the latest plugin templates. Non-destructive: never overwrite user customizations, always preview changes before applying.
+
+## When to Use
+
+- After plugin templates have been updated with new rules or improvements
+- When adding a rule file introduced after initial project setup
+- When checking if project rules are current with latest best practices
+- When updating global (`~/.claude/CLAUDE.md`) development instructions
+- When a user wants to know what changed in the templates since they last synced
+
+## Two Operating Levels
+
+### Project Level (`/update-rules project`)
+
+Update the current project's configuration:
+
+1. **`.rules/` directory sync** -- Compare each template rule file against the project's `.rules/` directory:
+   - `MISSING` -- new in templates, not in project. Show purpose and offer to add.
+   - `CHANGED` -- exists but differs from template. Show unified diff, suggest merge.
+   - `CURRENT` -- matches template. Report as up to date.
+   - `CUSTOM` -- user-added rule not in templates. Preserve completely, report.
+
+2. **`CLAUDE.md` section comparison** -- Extract H2 headers from both template and project CLAUDE.md. Identify missing sections. For matching sections, compare content and suggest updates. Preserve all project-specific customizations (replaced placeholders, custom guidelines, architecture maps).
+
+3. **What gets compared:**
+   - Template `rules/*.md` vs `.rules/*.md`
+   - Template `CLAUDE.md` sections vs `./CLAUDE.md` sections
+
+### User Level (`/update-rules user`)
+
+Update global development instructions:
+
+1. **Section analysis** -- Extract sections from `~/.claude/CLAUDE.md` and compare against template best practices and core principles.
+
+2. **Best practice suggestions:**
+   - New tool recommendations from templates
+   - New `[NEVER DO THIS]` entries (compare item-by-item)
+   - Updated workflow steps
+   - Sections in templates with no equivalent in user config
+
+3. **What gets compared:**
+   - User file sections vs template CLAUDE.md sections
+   - Template rules that have universal applicability (testing.md, git.md)
+   - Use `references/section-mapping.md` for cross-referencing sections
+
+## Comparison Workflow
+
+### Step 1: Run Comparison Script
+
+Run `project-diff-rules <level>` to get structured comparison data. The script outputs KEY=VALUE pairs categorizing each rule file and listing section headers from both sources.
+
+### Step 2: Read and Analyze
+
+For project level:
+- Read each `RULE_CHANGED` file from both template and project to understand the differences
+- Read CLAUDE.md from both sources to compare sections
+- Run `diff --unified "$(project-templates-path)/claude/rules/<file>" ".rules/<file>"` for each changed rule
+
+For user level:
+- Read `~/.claude/CLAUDE.md` in full
+- Read template CLAUDE.md and relevant rule files for best-practice content
+- Use `references/section-mapping.md` to map template sections to user sections
+
+### Step 3: Present Update Plan
+
+Present a numbered list of proposed changes. Each change marked as:
+- `[ADD]` -- New content to add
+- `[UPDATE]` -- Existing content to modify
+- `[INFO]` -- No change needed, already current
+
+Show preview of what will change for each item. Ask user to confirm which changes to apply. Never apply changes without confirmation.
+
+### Step 4: Apply Approved Changes
+
+- For existing files: use Edit tool for surgical modifications. Never use Write to overwrite.
+- For new .rules/ files: use Write to create them (safe, creating new file).
+- For CLAUDE.md sections: use Edit to insert or update specific sections.
+
+### Step 5: Verify
+
+Run `project-diff-rules <level>` again to confirm all approved changes were applied.
+
+## Non-Destructive Guarantees
+
+- NEVER overwrite a file without showing the diff first
+- NEVER remove user-added content (custom rules, custom sections, custom guidelines)
+- NEVER replace project-specific values (project name, tech stack, architecture) with template placeholders
+- ALWAYS use Edit for existing files, never Write (except for brand-new rule files)
+- For changed .rules/ files, present three options: (a) accept template version, (b) merge specific changes, (c) skip
+
+## Distinguishing Template Improvements from User Customizations
+
+For rule files: if the user has not modified the rule since init, it matches an older template version. The diff shows what the template improved. If the user customized it, the diff shows both template changes AND user changes; present both clearly and let the user decide.
+
+For CLAUDE.md: sections that still contain `{{PLACEHOLDERS}}` were never customized. Sections with replaced placeholders contain user-specific content. Template-originated content (like the "[NEVER DO THIS]" list) can be compared item-by-item.
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/section-mapping.md`** -- Maps template CLAUDE.md sections to user CLAUDE.md sections for intelligent cross-level comparison

--- a/plugins/project/skills/update-rules/references/section-mapping.md
+++ b/plugins/project/skills/update-rules/references/section-mapping.md
@@ -1,0 +1,69 @@
+# Section Mapping: Template vs User CLAUDE.md
+
+Maps sections between the template (project-level) CLAUDE.md and the typical user-level `~/.claude/CLAUDE.md` to enable intelligent comparison across levels.
+
+## Template -> User Section Mapping
+
+| Template Section | User Section | Comparison Notes |
+|---|---|---|
+| Project Context | Domain Context | Template has placeholders; user has personal specifics |
+| Architecture Map | (none) | Project-only; skip for user level |
+| Environment Setup | Tools | Both cover tool choices (UV, Bun, gh). Compare item-by-item |
+| Development Workflow | Git Workflow | Template has 10-step; user has 7-step. Compare steps |
+| [CRITICAL] Core Principles | (distributed) | User spreads across Testing, Linting, Code & Response Style |
+| [NEVER DO THIS] | [NEVER DO THIS] | Direct match. Compare item-by-item for missing entries |
+| Think Like a Senior Developer | Code & Response Style | Overlapping philosophy content |
+| Rules Directory | (none) | Project-only reference; skip for user level |
+| Context Files | Project Documentation | User describes .context/ convention |
+| Quick Commands | (none) | Project-specific; skip for user level |
+| Project-Specific Guidelines | (none) | Project-only; skip for user level |
+
+## Universal Sections
+
+These template sections contain universally applicable best practices. When comparing at user level, check that the user file covers these topics:
+
+- **[NEVER DO THIS]** -- compare item-by-item, suggest missing entries
+- **Tool choices** (UV, Bun, ruff, ty, biome) -- verify consistency between template and user
+- **Commit/PR standards** -- compare workflow steps, check for new best practices
+- **Testing philosophy** (NO MOCKS) -- verify presence and completeness
+- **Code review process** -- check PR review workflow is documented
+
+## Project-Only Sections
+
+These are only relevant at project level (skip when comparing user-level):
+
+- Architecture Map (project structure)
+- Rules Directory references (.rules/ file list)
+- Context Files references (.context/ file list)
+- Quick Commands (project-specific bash snippets)
+- Project-Specific Guidelines (custom section)
+
+## User-Only Sections
+
+These exist in user CLAUDE.md but not in templates. Preserve completely during updates:
+
+- Sprint/Feature Development Workflow (epic workflow with worktrees)
+- PR Review Process (review-pr integration details)
+- Writing Style (no em-dashes, abbreviation rules)
+- Session Start (date command convention)
+- Domain Context (personal research areas, tools, projects)
+- Merge Strategy (regular merge vs squash)
+- Linting & Type Checking (detailed tool config)
+
+## Template Rules with Universal Applicability
+
+These rule files from `templates/claude/rules/` contain best practices applicable at both levels. When updating user-level config, extract key principles from:
+
+- `testing.md` -- NO MOCKS policy, real data requirements
+- `git.md` -- commit messages, branch strategy, merge process
+- `code_review.md` -- PR review checklist, no-tech-debt policy
+- `self_improve.md` -- rule evolution, learning from projects
+
+## Template Rules that are Project-Specific
+
+These rules are primarily relevant to project-level updates:
+
+- `python.md` -- language-specific (only if Python project)
+- `ci_cd.md` -- CI/CD pipeline configuration
+- `documentation.md` -- MkDocs setup
+- `serena_mcp.md` -- code intelligence tools (only if Serena MCP available)

--- a/plugins/project/skills/update-rules/references/section-mapping.md
+++ b/plugins/project/skills/update-rules/references/section-mapping.md
@@ -10,9 +10,9 @@ Maps sections between the template (project-level) CLAUDE.md and the typical use
 | Architecture Map | (none) | Project-only; skip for user level |
 | Environment Setup | Tools | Both cover tool choices (UV, Bun, gh). Compare item-by-item |
 | Development Workflow | Git Workflow | Template has 10-step; user has 7-step. Compare steps |
-| [CRITICAL] Core Principles | (distributed) | User spreads across Testing, Linting, Code & Response Style |
+| [CRITICAL] Core Principles | (distributed) | User spreads across Testing, Linting & Type Checking, Code & Response Style |
 | [NEVER DO THIS] | [NEVER DO THIS] | Direct match. Compare item-by-item for missing entries |
-| Think Like a Senior Developer | Code & Response Style | Overlapping philosophy content |
+| Think Like a Senior Developer | Code & Response Style | Loosely related; template focuses on engineering mindset, user focuses on interaction style. Compare for non-overlapping best practices |
 | Rules Directory | (none) | Project-only reference; skip for user level |
 | Context Files | Project Documentation | User describes .context/ convention |
 | Quick Commands | (none) | Project-specific; skip for user level |


### PR DESCRIPTION
## Summary
- Add `/update-rules <user|project>` command for non-destructive sync of CLAUDE.md and .rules/ against latest templates
- Add `update-rules` skill with two operating levels, comparison strategy, and non-destructive guarantees
- Add `project-diff-rules` bin script for structured template-vs-existing comparison (KEY=VALUE output)
- Add section-mapping reference for intelligent cross-level CLAUDE.md comparison
- Bump project plugin 0.2.1 -> 0.2.2, marketplace 0.5.0 -> 0.5.1

## Test plan
- [x] `project-diff-rules project` outputs correct RULE_MISSING/CHANGED/CURRENT/CUSTOM categories
- [x] `project-diff-rules user` outputs section headers from both user and template files
- [x] Error handling: no args, invalid level, missing target dir all exit cleanly
- [x] Idempotent: running twice produces consistent output
- [ ] End-to-end: run `/update-rules project` in a project with .rules/ and verify preview/apply flow
- [ ] End-to-end: run `/update-rules user` and verify best-practice suggestions

Closes #19