### PR TITLE
scientific-figures: add Codex CLI image_gen backend with auto-fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Claude Code plugins for academic research and development: literature search and review, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -59,7 +59,7 @@
     {
       "name": "scientific-figures",
       "description": "Publication-quality scientific figures: icons, plots, react-pdf composition, and visual QA for Nature/Science/PNAS journals",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ research-skills/
 - **grant** (v0.2.0): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance
 - **manuscript** (v0.2.0): Academic manuscript peer review, writing guidance, and journal-specific formatting for submission
 - **opencite** (v0.2.0): Academic literature search, citation management, PDF retrieval, and literature review synthesis
-- **scientific-figures** (v0.1.1): Publication-quality figures covering icons, plots, composition, and QA
+- **scientific-figures** (v0.2.0): Publication-quality figures covering icons, plots, composition, and QA. Icon generation auto-selects between Codex CLI (`codex login`) and OpenAI API (`OPENAI_API_KEY`).
 - **presentation** (v0.1.0): Interactive Reveal.js presentations from JSON via the Agentic Presentation Builder
 - **neuroinformatics** (v0.1.0): Neuroscience data standards (BIDS, HED), experiment design (PsychoPy, LSL), and dataset validation
 

--- a/plugins/scientific-figures/.claude-plugin/plugin.json
+++ b/plugins/scientific-figures/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scientific-figures",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Publication-quality scientific figures: icons, plots, react-pdf composition, and visual QA for Nature/Science/PNAS journals",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/scientific-figures/skills/scientific-figures/SKILL.md
+++ b/plugins/scientific-figures/skills/scientific-figures/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-figures
 description: This skill should be used when the user asks to "create a figure", "make a scientific figure", "create a paper figure", "generate a figure element", "make an icon", "plot data for a figure", "compose figure panels", "create a graphical abstract", "make a multi-panel figure", "generate a PDF figure", "create a Nature-style figure", "make a publication figure", "create a figure for my grant", "make a poster figure", "create a schematic diagram", or mentions scientific figures, figure elements, figure composition, figure panels, icons for papers, matplotlib/seaborn/ggplot plots for figures, or react-pdf figures.
-version: 0.1.1
+version: 0.2.0
 ---
 
 # Scientific Figures
@@ -49,12 +49,21 @@ Each panel contains one or more elements. Generate them as SVG or transparent PN
 
 Flat, minimalist scientific icons in Nature/Science style. See `references/element-icons.md` for full guide.
 
+The script auto-selects between two backends:
+- **codex** (preferred when available): uses the local Codex CLI's platform-native image_gen tool. Requires `codex login` (ChatGPT subscription or API key in `~/.codex/auth.json`). No `OPENAI_API_KEY` needed.
+- **api** (fallback): calls the OpenAI Images API directly. Requires `OPENAI_API_KEY`.
+
+Override with `--backend codex` or `--backend api`.
+
 ```bash
-# From template (icon bible)
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template brain-eeg -o elements/brain.png --transparent
+# From template (icon bible) -- backend chosen automatically
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template brain-eeg -o elements/brain.png --transparent
 
 # Free-form
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a DNA helix" -o elements/dna.png --transparent
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a DNA helix" -o elements/dna.png --transparent
+
+# Force the OpenAI API path
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template neuron --backend api -o elements/neuron.png
 ```
 
 Template catalog: `references/icon-templates.json`. Schema: `references/icon-bible.md`.
@@ -209,4 +218,4 @@ Generate a figure caption that:
 - **`examples/matplotlib-element.py`** - Publication-quality matplotlib element
 
 ### Scripts
-- **`scripts/generate_icon.py`** - Icon generation via gpt-image-2 (template and free-form)
+- **`scripts/generate_icon.py`** - Icon generation via gpt-image-2 (template and free-form). Auto-selects between Codex CLI (`codex login`) and OpenAI API (`OPENAI_API_KEY`); override with `--backend codex|api`.

--- a/plugins/scientific-figures/skills/scientific-figures/references/element-icons.md
+++ b/plugins/scientific-figures/skills/scientific-figures/references/element-icons.md
@@ -2,6 +2,15 @@
 
 Generate flat, minimalist scientific icons in the style of Nature, Science, and Cell journal figures using OpenAI's gpt-image-2 model.
 
+## Backends
+
+`scripts/generate_icon.py` auto-selects one of two backends:
+
+1. **codex** (preferred): invokes the local Codex CLI's platform-native `image_gen` tool inside a temp workspace, then returns the saved PNG. Works with a ChatGPT subscription or API-key login (`codex login`); no `OPENAI_API_KEY` is required.
+2. **api**: calls `client.images.generate(model="gpt-image-2", ...)` against the OpenAI API. Requires `OPENAI_API_KEY`.
+
+Auto rule: codex is used when both the `codex` binary is on PATH and `~/.codex/auth.json` (or `CODEX_HOME/auth.json`) exists; otherwise the API path is used. Override with `--backend codex` or `--backend api`.
+
 ## When to Use Icons
 
 Icons serve as visual shorthand in multi-panel figures, graphical abstracts, and workflow diagrams. They represent concepts (brain, neuron, sensor, patient) without photographic detail.
@@ -24,16 +33,16 @@ Predefined templates in `icon-templates.json` define elements, shapes, colors, a
 
 ```bash
 # Generate from template
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template brain-eeg -o elements/brain.png --transparent
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template brain-eeg -o elements/brain.png --transparent
 
 # Override colors
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template neuron --colors "#0072B2,#D55E00" -o elements/neuron.png
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template neuron --colors "#0072B2,#D55E00" -o elements/neuron.png
 
 # Generate all icons in a category
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --category neuroscience -o elements/
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --category neuroscience -o elements/
 
 # List available templates
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --list-templates
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --list-templates
 ```
 
 ### Free-form generation
@@ -41,13 +50,13 @@ uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --list-
 For one-off icons not in the template catalog:
 
 ```bash
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a human brain with EEG electrodes" -o elements/brain.png --transparent
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a human brain with EEG electrodes" -o elements/brain.png --transparent
 
 # With specific colors
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a neuron" -o elements/neuron.png --colors "teal,white" --transparent
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a neuron" -o elements/neuron.png --colors "teal,white" --transparent
 
 # Batch generation
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a flat icon of a {item}" -o elements/ --batch "brain,heart,lung"
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a flat icon of a {item}" -o elements/ --batch "brain,heart,lung"
 ```
 
 ## Prompt Engineering
@@ -89,12 +98,14 @@ Common adjustments after generation:
 
 ## Configuration
 
-The generation script reads `OPENAI_API_KEY` from:
+When the **codex** backend is selected, the script invokes `codex exec` and relies on the existing Codex CLI login (`~/.codex/auth.json` or `CODEX_HOME/auth.json`). Run `codex login` once if not already authenticated.
+
+When the **api** backend is selected, the script reads `OPENAI_API_KEY` from:
 1. `.env` file in the current directory
 2. `~/.env` file
 3. Environment variable
 
-Dependencies are handled on-the-fly via `uvx --from "openai python-dotenv pillow"`.
+Dependencies are handled on-the-fly via `uv run --with openai --with python-dotenv --with pillow`. The `openai` package is only required for the `api` backend; `python-dotenv` and `pillow` are used by both.
 
 ## Available Template Categories
 

--- a/plugins/scientific-figures/skills/scientific-figures/references/icon-bible.md
+++ b/plugins/scientific-figures/skills/scientific-figures/references/icon-bible.md
@@ -176,14 +176,14 @@ The script can read templates from the icon bible:
 
 ```bash
 # Generate from a template
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template brain-eeg -o brain_eeg.png
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template brain-eeg -o brain_eeg.png
 
 # Override colors from template
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template brain-eeg --colors "#3498DB,#E74C3C" -o brain_eeg_alt.png
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template brain-eeg --colors "#3498DB,#E74C3C" -o brain_eeg_alt.png
 
 # Generate all icons in a category
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --category neuroscience -o icons/neuro/
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --category neuroscience -o icons/neuro/
 
 # List available templates
-uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --list-templates
+uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --list-templates
 ```

--- a/plugins/scientific-figures/skills/scientific-figures/scripts/generate_icon.py
+++ b/plugins/scientific-figures/skills/scientific-figures/scripts/generate_icon.py
@@ -12,7 +12,7 @@ Two backends are supported and auto-selected by default:
 Auto selection prefers codex when both `codex` is on PATH and
 ~/.codex/auth.json exists; otherwise it falls back to the API.
 
-Recommended runner (single package via --from, extras via --with):
+Recommended runner (declares all deps via --with):
     uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py ...
 
 Usage:
@@ -62,7 +62,11 @@ from typing import Any, Optional
 try:
     from dotenv import load_dotenv
 except ImportError:
-    print("Missing dependency: python-dotenv. Run via: uvx --from \"openai python-dotenv pillow\" python scripts/generate_icon.py")
+    print(
+        "Missing dependency: python-dotenv. Run via: "
+        "uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 try:
@@ -159,14 +163,18 @@ def build_prompt(subject: str, colors: str | None = None, transparent: bool = Fa
 
 
 def codex_available() -> bool:
-    """Detect a usable Codex CLI install with valid auth."""
+    """Detect a usable Codex CLI install with valid auth.
+
+    Auth is gated on the Codex CLI auth file (`$CODEX_HOME/auth.json`, default
+    `~/.codex/auth.json`). Env-var-only paths are intentionally NOT treated as
+    Codex auth: a user with `OPENAI_API_KEY` set but no `codex login` would
+    otherwise be silently routed through `codex exec` and hit a runtime auth
+    error instead of the OpenAI Images API.
+    """
     if shutil.which("codex") is None:
         return False
     codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
-    if (codex_home / "auth.json").exists():
-        return True
-    # Env-only auth path also valid for Codex
-    return bool(os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY"))
+    return (codex_home / "auth.json").exists()
 
 
 def resolve_backend(requested: str) -> str:
@@ -175,16 +183,38 @@ def resolve_backend(requested: str) -> str:
         return "codex" if codex_available() else "api"
     if requested == "codex":
         if not codex_available():
-            print("Backend 'codex' requested but no Codex CLI/auth found. Run: codex login")
+            print(
+                "Backend 'codex' requested but no Codex CLI/auth found. "
+                "Run: codex login",
+                file=sys.stderr,
+            )
             sys.exit(1)
         return "codex"
     if requested == "api":
         if OpenAI is None:
-            print("Backend 'api' requested but `openai` is not installed.")
+            print(
+                "Backend 'api' requested but `openai` is not installed.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         return "api"
-    print(f"Unknown backend: {requested}")
+    print(f"Unknown backend: {requested}", file=sys.stderr)
     sys.exit(1)
+
+
+def build_openai_client() -> Any:
+    """Construct the OpenAI client with a friendly error if no API key is set."""
+    assert OpenAI is not None  # caller routes via resolve_backend()
+    try:
+        return OpenAI()  # reads OPENAI_API_KEY from env
+    except Exception as exc:  # OpenAI raises OpenAIError when key is missing
+        print(
+            "Backend 'api' requires OPENAI_API_KEY. "
+            "Set it in your environment, .env, or ~/.env, "
+            f"or use --backend codex if you have run `codex login`. ({exc})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def generate_icon_api(
@@ -236,6 +266,10 @@ def generate_icon_codex(
     workdir = Path(tempfile.mkdtemp(prefix="codex_icon_"))
     target = workdir / "output.png"
     try:
+        # The user-supplied `prompt` is concatenated into a natural-language
+        # instruction below. We trust the prompt because it originates from
+        # the same shell session that runs this script; if you ever surface
+        # this script over an untrusted boundary, sanitize `prompt` first.
         codex_prompt = (
             f"Use your platform-native image_gen tool to generate exactly one image. "
             f"Prompt: {prompt} "
@@ -244,30 +278,61 @@ def generate_icon_codex(
             f"Do not display the image inline. "
             f"Reply with only the absolute path on success or ERROR on failure."
         )
-        proc = subprocess.run(
-            [
-                "codex", "exec",
-                "--sandbox", "workspace-write",
-                "--skip-git-repo-check",
-                codex_prompt,
-            ],
-            cwd=workdir,
-            capture_output=True,
-            text=True,
-            timeout=timeout_s,
-        )
+        try:
+            proc = subprocess.run(
+                [
+                    "codex", "exec",
+                    "--sandbox", "workspace-write",
+                    "--skip-git-repo-check",
+                    codex_prompt,
+                ],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stderr_tail = _safe_tail(exc.stderr, 300)
+            raise RuntimeError(
+                f"Codex exec timed out after {timeout_s}s. "
+                f"Try --backend api or raise the timeout. "
+                f"stderr tail: {stderr_tail}"
+            ) from exc
+
+        # Surface non-zero exits explicitly. Codex emits an unrelated
+        # "failed to record rollout items" stderr line on success too, so we
+        # rely on returncode rather than stderr scanning.
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Codex exec exited rc={proc.returncode}. "
+                f"stderr tail: {_safe_tail(proc.stderr, 300)}"
+            )
         if not target.exists():
             raise RuntimeError(
-                "Codex did not produce ./output.png.\n"
-                f"stdout tail: {(proc.stdout or '')[-500:]}\n"
-                f"stderr tail: {(proc.stderr or '')[-500:]}"
+                "Codex exec succeeded but did not produce ./output.png. "
+                f"stderr tail: {_safe_tail(proc.stderr, 300)}"
             )
         image_data = target.read_bytes()
         if transparent and HAS_PILLOW:
             image_data = _apply_transparency(image_data)
         return image_data
     finally:
+        # Best-effort cleanup; tempfile.mkdtemp guarantees an isolated path,
+        # so a stale dir at most leaks a few MB into $TMPDIR.
         shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _safe_tail(s: Any, n: int) -> str:
+    """Tail-truncate stderr for error messages without echoing the
+    user-supplied prompt. Codex echoes the prompt into stdout but not stderr,
+    so we never use stdout for diagnostics. Accepts str/bytes/None because
+    subprocess.TimeoutExpired carries bytes even under text=True."""
+    if not s:
+        return "(empty)"
+    if isinstance(s, bytes):
+        s = s.decode("utf-8", errors="replace")
+    return s[-n:]
 
 
 def generate_icon(
@@ -381,11 +446,7 @@ def main() -> None:
         args.transparent = False
 
     backend = resolve_backend(args.backend)
-    if backend == "api":
-        assert OpenAI is not None  # ensured by resolve_backend()
-        client: Any = OpenAI()  # reads OPENAI_API_KEY from env
-    else:
-        client = None
+    client: Any = build_openai_client() if backend == "api" else None
     print(f"Backend: {backend}")
 
     # Category batch mode

--- a/plugins/scientific-figures/skills/scientific-figures/scripts/generate_icon.py
+++ b/plugins/scientific-figures/skills/scientific-figures/scripts/generate_icon.py
@@ -1,38 +1,63 @@
 #!/usr/bin/env python3
-"""Generate flat scientific icons using OpenAI's gpt-image-2 model.
+"""Generate flat scientific icons using gpt-image-2.
+
+Two backends are supported and auto-selected by default:
+
+  1. codex   - Uses the Codex CLI's platform-native image_gen tool. Requires a
+               valid `codex login` (ChatGPT subscription or API key in
+               ~/.codex/auth.json). No OPENAI_API_KEY needed.
+  2. api     - Calls the OpenAI Images API directly. Requires OPENAI_API_KEY
+               via environment, .env, or ~/.env.
+
+Auto selection prefers codex when both `codex` is on PATH and
+~/.codex/auth.json exists; otherwise it falls back to the API.
+
+Recommended runner (single package via --from, extras via --with):
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py ...
 
 Usage:
     # Free-form prompt
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a human brain with EEG electrodes" -o brain_eeg.png
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a human brain with EEG electrodes" -o brain_eeg.png
 
     # From template (icon bible)
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template brain-eeg -o brain_eeg.png
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template brain-eeg -o brain_eeg.png
 
     # Override template colors
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template neuron --colors "#3498DB,#E74C3C" -o neuron.png
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template neuron --colors "#3498DB,#E74C3C" -o neuron.png
 
     # With transparency
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --template dna-helix -o dna.png --transparent
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template dna-helix -o dna.png --transparent
 
     # Batch from template category
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --category neuroscience -o icons/neuro/
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --category neuroscience -o icons/neuro/
 
     # Batch from free-form prompt
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py "a flat icon of a {item}" -o icons/ --batch "brain,heart,lung"
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py "a flat icon of a {item}" -o icons/ --batch "brain,heart,lung"
+
+    # Force a backend
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template neuron --backend codex -o neuron.png
+    uv run --with openai --with python-dotenv --with pillow python scripts/generate_icon.py --template neuron --backend api   -o neuron.png
 
     # List available templates
-    uvx --from "openai python-dotenv pillow" python scripts/generate_icon.py --list-templates
+    uv run --with python-dotenv python scripts/generate_icon.py --list-templates
 
 Environment:
-    OPENAI_API_KEY - Required. Read from .env file or environment variable.
+    OPENAI_API_KEY - Required for the api backend. Read from .env file or environment.
+    CODEX_HOME     - Optional; defaults to ~/.codex. Auth probed at $CODEX_HOME/auth.json.
 """
+
+from __future__ import annotations
 
 import argparse
 import base64
 import json
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 try:
     from dotenv import load_dotenv
@@ -43,8 +68,7 @@ except ImportError:
 try:
     from openai import OpenAI
 except ImportError:
-    print("Missing dependency: openai. Run via: uvx --from \"openai python-dotenv pillow\" python scripts/generate_icon.py")
-    sys.exit(1)
+    OpenAI = None  # api backend unavailable; codex backend may still work
 
 try:
     from PIL import Image
@@ -134,13 +158,42 @@ def build_prompt(subject: str, colors: str | None = None, transparent: bool = Fa
     return ", ".join(parts) + "."
 
 
-def generate_icon(
-    client: OpenAI,
+def codex_available() -> bool:
+    """Detect a usable Codex CLI install with valid auth."""
+    if shutil.which("codex") is None:
+        return False
+    codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    if (codex_home / "auth.json").exists():
+        return True
+    # Env-only auth path also valid for Codex
+    return bool(os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY"))
+
+
+def resolve_backend(requested: str) -> str:
+    """Resolve `auto` to a concrete backend; validate explicit choices."""
+    if requested == "auto":
+        return "codex" if codex_available() else "api"
+    if requested == "codex":
+        if not codex_available():
+            print("Backend 'codex' requested but no Codex CLI/auth found. Run: codex login")
+            sys.exit(1)
+        return "codex"
+    if requested == "api":
+        if OpenAI is None:
+            print("Backend 'api' requested but `openai` is not installed.")
+            sys.exit(1)
+        return "api"
+    print(f"Unknown backend: {requested}")
+    sys.exit(1)
+
+
+def generate_icon_api(
+    client: Any,
     prompt: str,
     size: int = 1024,
     transparent: bool = False,
 ) -> bytes:
-    """Generate a single icon and return PNG bytes."""
+    """Generate a single icon via the OpenAI Images API."""
     size_str = f"{size}x{size}"
 
     # gpt-image-2 supports flexible sizes (multiples of 16, max edge 3840, aspect <=3:1)
@@ -162,11 +215,76 @@ def generate_icon(
 
     image_data = base64.b64decode(result.data[0].b64_json)
 
-    # Apply transparency if requested and Pillow is available
     if transparent and HAS_PILLOW:
         image_data = _apply_transparency(image_data)
 
     return image_data
+
+
+def generate_icon_codex(
+    prompt: str,
+    size: int = 1024,
+    transparent: bool = False,
+    timeout_s: int = 300,
+) -> bytes:
+    """Generate a single icon by invoking the Codex CLI's image_gen tool.
+
+    The CLI runs in a temp workspace with `--sandbox workspace-write`; the
+    selected image is saved to ./output.png inside that workspace, which we
+    then read back as bytes.
+    """
+    workdir = Path(tempfile.mkdtemp(prefix="codex_icon_"))
+    target = workdir / "output.png"
+    try:
+        codex_prompt = (
+            f"Use your platform-native image_gen tool to generate exactly one image. "
+            f"Prompt: {prompt} "
+            f"Square aspect, target {size}x{size}. "
+            f"Save the final selected image to ./output.png in the current working directory. "
+            f"Do not display the image inline. "
+            f"Reply with only the absolute path on success or ERROR on failure."
+        )
+        proc = subprocess.run(
+            [
+                "codex", "exec",
+                "--sandbox", "workspace-write",
+                "--skip-git-repo-check",
+                codex_prompt,
+            ],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        if not target.exists():
+            raise RuntimeError(
+                "Codex did not produce ./output.png.\n"
+                f"stdout tail: {(proc.stdout or '')[-500:]}\n"
+                f"stderr tail: {(proc.stderr or '')[-500:]}"
+            )
+        image_data = target.read_bytes()
+        if transparent and HAS_PILLOW:
+            image_data = _apply_transparency(image_data)
+        return image_data
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def generate_icon(
+    backend: str,
+    client: Optional[Any],
+    prompt: str,
+    size: int = 1024,
+    transparent: bool = False,
+) -> bytes:
+    """Dispatch to the selected backend."""
+    if backend == "codex":
+        return generate_icon_codex(prompt, size=size, transparent=transparent)
+    if backend == "api":
+        if client is None:
+            raise RuntimeError("OpenAI client unavailable for api backend")
+        return generate_icon_api(client, prompt, size=size, transparent=transparent)
+    raise ValueError(f"Unknown backend: {backend}")
 
 
 def _apply_transparency(png_bytes: bytes, threshold: int = 240) -> bytes:
@@ -225,6 +343,12 @@ def main() -> None:
     parser.add_argument("--batch", help="Comma-separated items for batch generation (use {item} in prompt)")
     parser.add_argument("--list-templates", action="store_true", help="List available icon templates")
     parser.add_argument("--templates-file", type=Path, help="Custom templates JSON file")
+    parser.add_argument(
+        "--backend",
+        choices=["auto", "codex", "api"],
+        default="auto",
+        help="Image generation backend (default: auto; prefers codex when authenticated)",
+    )
     args = parser.parse_args()
 
     # Load templates
@@ -252,11 +376,17 @@ def main() -> None:
         parser.error("--output is required")
 
     if args.transparent and not HAS_PILLOW:
-        print("Warning: --transparent requires Pillow. Ensure pillow is included in the uvx --from dependencies.")
+        print("Warning: --transparent requires Pillow. Ensure pillow is included in the uv run --with dependencies.")
         print("Generating without transparency.")
         args.transparent = False
 
-    client = OpenAI()  # reads OPENAI_API_KEY from env
+    backend = resolve_backend(args.backend)
+    if backend == "api":
+        assert OpenAI is not None  # ensured by resolve_backend()
+        client: Any = OpenAI()  # reads OPENAI_API_KEY from env
+    else:
+        client = None
+    print(f"Backend: {backend}")
 
     # Category batch mode
     if args.category:
@@ -272,7 +402,7 @@ def main() -> None:
             prompt = template_to_prompt(t, color_override=args.colors)
             transparent = args.transparent or t.get("composition", {}).get("background") == "transparent"
             print(f"Generating: {t['id']}...")
-            data = generate_icon(client, prompt, size=args.size, transparent=transparent)
+            data = generate_icon(backend, client, prompt, size=args.size, transparent=transparent)
             save_icon(data, output_dir / f"{t['id']}.png")
         return
 
@@ -287,7 +417,7 @@ def main() -> None:
         transparent = args.transparent or t.get("composition", {}).get("background") == "transparent"
         print(f"Generating from template: {args.template}")
         print(f"Prompt: {prompt[:200]}...")
-        data = generate_icon(client, prompt, size=args.size, transparent=transparent)
+        data = generate_icon(backend, client, prompt, size=args.size, transparent=transparent)
         save_icon(data, Path(args.output))
         return
 
@@ -304,7 +434,7 @@ def main() -> None:
                 transparent=args.transparent,
             )
             print(f"Generating: {item}...")
-            data = generate_icon(client, prompt, size=args.size, transparent=args.transparent)
+            data = generate_icon(backend, client, prompt, size=args.size, transparent=args.transparent)
             save_icon(data, output_dir / f"{item.replace(' ', '_')}.png")
         return
 
@@ -312,7 +442,7 @@ def main() -> None:
     prompt = build_prompt(args.prompt, colors=args.colors, transparent=args.transparent)
     print(f"Generating icon...")
     print(f"Prompt: {prompt}")
-    data = generate_icon(client, prompt, size=args.size, transparent=args.transparent)
+    data = generate_icon(backend, client, prompt, size=args.size, transparent=args.transparent)
     save_icon(data, Path(args.output))
 
 


### PR DESCRIPTION
Closes #21

## Summary
- New `--backend auto|codex|api` flag in `scripts/generate_icon.py`. Default `auto` prefers the Codex CLI when `~/.codex/auth.json` exists and `codex` is on PATH; otherwise falls back to the OpenAI Images API.
- Codex backend runs `codex exec --sandbox workspace-write --skip-git-repo-check` in a temp workspace and reads the saved `./output.png`. Existing transparency post-processing (Pillow) is reused.
- Fix pre-existing broken `uvx --from \"openai python-dotenv pillow\"` invocations: current `uvx --from` accepts only a single package spec, so docs and the script docstring now use `uv run --with openai --with python-dotenv --with pillow ...`.
- Versions: scientific-figures `0.1.2 -> 0.2.0` (minor; new backend), marketplace `0.5.2 -> 0.5.3` (patch).

## Why
Researchers with a ChatGPT subscription should not need a separate `OPENAI_API_KEY` to use the icon generator. Codex CLI exposes a built-in `image_gen` tool that satisfies this on the user's existing login.

## Test plan
- [x] `--backend codex` produces a valid 1024x1024 PNG (verified end-to-end with a transparent neuron icon, 625 KB RGBA)
- [x] `--backend api` still produces a valid PNG (verified with a microscope icon, 796 KB)
- [x] `--backend auto` selects codex when the binary + `auth.json` are present
- [x] Codex preflight refuses gracefully when neither auth nor CLI is available (clear "run `codex login`" message)
- [ ] CI green