### PR TITLE
manuscript: add lit-review workflow skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Claude Code plugins for academic research and development: literature search and review, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -34,8 +34,8 @@
     },
     {
       "name": "manuscript",
-      "description": "Academic manuscript toolkit: peer review, manuscript writing, and journal-specific formatting for submission",
-      "version": "0.2.0",
+      "description": "Academic manuscript toolkit: multi-phase literature review, peer review, manuscript writing, and journal-specific formatting for submission",
+      "version": "0.3.0",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ research-skills/
 │   │   └── agents/grant-figure-qa.md
 │   ├── manuscript/                   # Academic manuscript toolkit
 │   │   ├── .claude-plugin/plugin.json
-│   │   ├── commands/{paper-review,manuscript-prep}.md
-│   │   └── skills/{paper-review,manuscript-writing,manuscript-formatting}/
+│   │   ├── commands/{paper-review,manuscript-prep,lit-review}.md
+│   │   └── skills/{paper-review,manuscript-writing,manuscript-formatting,lit-review}/
 │   ├── opencite/                     # Literature search and review
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── commands/opencite.md
@@ -47,7 +47,7 @@ research-skills/
 ## Plugins
 - **project** (v0.2.2): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing
 - **grant** (v0.2.0): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance
-- **manuscript** (v0.2.0): Academic manuscript peer review, writing guidance, and journal-specific formatting for submission
+- **manuscript** (v0.3.0): Multi-phase literature review (briefs, paper-card collection, synthesis, direction papers), peer review, writing guidance, and journal-specific formatting for submission
 - **opencite** (v0.2.0): Academic literature search, citation management, PDF retrieval, and literature review synthesis
 - **scientific-figures** (v0.2.0): Publication-quality figures covering icons, plots, composition, and QA. Icon generation auto-selects between Codex CLI (`codex login`) and OpenAI API (`OPENAI_API_KEY`).
 - **presentation** (v0.1.0): Interactive Reveal.js presentations from JSON via the Agentic Presentation Builder

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ done
 |--------|---------|-------------|----------|
 | **project** | 0.2.2 | Project lifecycle: init, rule/config updates, workflow, CI/CD, Docker, security, doc-processing | `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/setup-ci`, `/release-prep`, `/doc-process` |
 | **grant** | 0.2.0 | NIH/NSF grant proposal writing, review, and figure QA | `/grant-write`, `/grant-review` |
-| **manuscript** | 0.2.0 | Academic manuscript peer review, writing, and journal formatting | `/paper-review`, `/manuscript-prep` |
+| **manuscript** | 0.3.0 | Academic manuscript multi-phase lit review, peer review, writing, and journal formatting | `/paper-review`, `/manuscript-prep`, `/lit-review` |
 | **opencite** | 0.2.0 | Literature search, citation management, PDF retrieval, literature review synthesis | `/opencite` |
 | **scientific-figures** | 0.1.1 | Full figure pipeline: icons, plots, composition, visual QA | -- |
 | **presentation** | 0.1.0 | Interactive Reveal.js presentations from JSON | `/create-presentation` |
@@ -56,11 +56,15 @@ Draft and review NIH and NSF grant proposals with mechanism-specific templates (
 
 ### manuscript
 
-Academic manuscript toolkit covering the full lifecycle: writing guidance (IMRAD structure, section templates), peer review (methodology, statistics, reproducibility), and journal-specific formatting (IEEE, Nature, PNAS, Elsevier, LaTeX/BibTeX management). Includes revision response templates.
+Academic manuscript toolkit covering the full lifecycle: multi-phase literature review (briefs, paper-card collection, taxonomic synthesis, citation-grounded direction papers), writing guidance (IMRAD structure, section templates), peer review (methodology, statistics, reproducibility), and journal-specific formatting (IEEE, Nature, PNAS, Elsevier, LaTeX/BibTeX management). Includes revision response templates.
+
+The lit-review skill captures a rigorous, iterable, citation-traceable workflow: every claim in a direction paper links back to a paper-card on disk. Differs from `opencite:literature-review` (single-pass synthesis) by orchestrating parallel strand collection, taxonomic synthesis with bias gates, and review loops.
 
 ```
 /paper-review manuscript.pdf
 /manuscript-prep "Nature Neuroscience"
+/lit-review --init
+/lit-review --phase collect --strand tools
 ```
 
 ### scientific-figures

--- a/plugins/manuscript/.claude-plugin/plugin.json
+++ b/plugins/manuscript/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "manuscript",
-  "version": "0.2.0",
-  "description": "Academic manuscript toolkit: peer review, manuscript writing, and journal-specific formatting for submission",
+  "version": "0.3.0",
+  "description": "Academic manuscript toolkit: multi-phase literature review, peer review, manuscript writing, and journal-specific formatting for submission",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"
   },
   "license": "BSD-3-Clause",
-  "keywords": ["manuscript", "paper", "peer-review", "writing", "formatting", "journal", "latex", "submission", "academic"]
+  "keywords": ["manuscript", "paper", "peer-review", "writing", "formatting", "journal", "latex", "submission", "academic", "literature-review", "lit-review", "direction-paper"]
 }

--- a/plugins/manuscript/commands/lit-review.md
+++ b/plugins/manuscript/commands/lit-review.md
@@ -1,0 +1,60 @@
+---
+description: Orchestrate a multi-phase, citation-grounded literature review
+argument-hint: [--phase brief|collect|synthesize|direct|review] [--strand <name>] [--init <path>]
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# Multi-Phase Literature Review
+
+Orchestrate a rigorous lit-review workflow across phases. Load the `manuscript:lit-review` skill for the full protocol, schemas, and templates.
+
+## Process
+
+### 1. Identify intent
+
+!echo "Args: $ARGUMENTS"
+
+Parse arguments:
+- `--init <path>`: bootstrap a new lit-review root at `<path>` (or current dir if omitted). Create `_briefs/`, `research/collection/_schema/`, `research/synthesis/`, `direction-papers/` on demand. Drop `paper-card.md` schema as `research/collection/_schema/paper-card.md` (copy from skill references).
+- `--phase brief`: route to Phase 0 guidance. Inputs: prior work, gap statement, epic-dev findings. Output: one brief per strand in `_briefs/strand-<name>.md`.
+- `--phase collect [--strand <name>]`: route to Phase 1. Inputs: a brief. Output: paper-cards under `research/collection/<strand>/`. Use `opencite:opencite` for paper ops.
+- `--phase synthesize`: route to Phase 2. Inputs: full collection. Outputs: `synthesis/<strand>-ontology.md`, `<domain>-map.md`, `gap-analysis.md`, `scope-diagram.md`.
+- `--phase direct`: route to Phase 3. Inputs: synthesis + briefs. Output: `direction-papers/<topic>-direction.md`.
+- `--phase review`: route to Phase 4. Self-review the latest direction paper using `manuscript:paper-review`. Loop back to prior phases as needed.
+
+If no argument, infer phase from current directory state:
+- No `_briefs/` -> Phase 0 (suggest `--init` first if root is empty).
+- `_briefs/` populated, `research/collection/` empty or partial -> Phase 1.
+- `research/collection/` complete per brief acceptance, `synthesis/` empty -> Phase 2.
+- `synthesis/` populated, `direction-papers/` empty -> Phase 3.
+- `direction-papers/` populated -> Phase 4.
+
+### 2. Locate state
+
+!ls -d _briefs research/collection research/synthesis direction-papers 2>/dev/null
+!find _briefs -name 'strand-*.md' 2>/dev/null | head -20
+!find research/collection -mindepth 2 -maxdepth 2 -type d 2>/dev/null | head -20
+!ls research/synthesis 2>/dev/null
+!ls direction-papers 2>/dev/null
+
+### 3. Route to phase
+
+Load the `manuscript:lit-review` skill and apply its phase-specific guidance:
+
+- Phase 0 (Briefs): use `references/brief-template.md`.
+- Phase 1 (Collection): use `references/paper-card-schema.md` and `references/license-rules.md`. Dispatch parallel strand agents if multiple briefs exist.
+- Phase 2 (Synthesis): use `references/synthesis-templates.md`. Apply bias rules.
+- Phase 3 (Direction): use `references/direction-paper-template.md`. Delegate prose discipline to `manuscript:manuscript-writing` and review-paper structuring to `manuscript:manuscript-prep`.
+- Phase 4 (Review): invoke `manuscript:paper-review` on the latest direction paper. Disposition each concern (ground / restructure / drop). Loop back as needed.
+
+### 4. Apply rigor checklist
+
+Before declaring a phase done, walk `references/rigor-checklist.md` for the active phase. Loop back if any item fails.
+
+### 5. Report
+
+Summarize:
+- Active phase
+- Acceptance criteria met / outstanding
+- Suggested next phase
+- Outstanding loop-backs (if any)

--- a/plugins/manuscript/commands/lit-review.md
+++ b/plugins/manuscript/commands/lit-review.md
@@ -18,15 +18,15 @@ Parse arguments:
 - `--init <path>`: bootstrap a new lit-review root at `<path>` (or current dir if omitted). Create `_briefs/`, `research/collection/_schema/`, `research/synthesis/`, `direction-papers/` on demand. Drop `paper-card.md` schema as `research/collection/_schema/paper-card.md` (copy from skill references).
 - `--phase brief`: route to Phase 0 guidance. Inputs: prior work, gap statement, epic-dev findings. Output: one brief per strand in `_briefs/strand-<name>.md`.
 - `--phase collect [--strand <name>]`: route to Phase 1. Inputs: a brief. Output: paper-cards under `research/collection/<strand>/`. Use `opencite:opencite` for paper ops.
-- `--phase synthesize`: route to Phase 2. Inputs: full collection. Outputs: `synthesis/<strand>-ontology.md`, `<domain>-map.md`, `gap-analysis.md`, `scope-diagram.md`.
+- `--phase synthesize`: route to Phase 2. Inputs: full collection. Outputs in `research/synthesis/`: `<strand>-ontology.md`, `<domain>-map.md`, `gap-analysis.md`, `scope-diagram.md`.
 - `--phase direct`: route to Phase 3. Inputs: synthesis + briefs. Output: `direction-papers/<topic>-direction.md`.
 - `--phase review`: route to Phase 4. Self-review the latest direction paper using `manuscript:paper-review`. Loop back to prior phases as needed.
 
 If no argument, infer phase from current directory state:
 - No `_briefs/` -> Phase 0 (suggest `--init` first if root is empty).
 - `_briefs/` populated, `research/collection/` empty or partial -> Phase 1.
-- `research/collection/` complete per brief acceptance, `synthesis/` empty -> Phase 2.
-- `synthesis/` populated, `direction-papers/` empty -> Phase 3.
+- `research/collection/` complete per brief acceptance, `research/synthesis/` empty -> Phase 2.
+- `research/synthesis/` populated, `direction-papers/` empty -> Phase 3.
 - `direction-papers/` populated -> Phase 4.
 
 ### 2. Locate state
@@ -44,7 +44,7 @@ Load the `manuscript:lit-review` skill and apply its phase-specific guidance:
 - Phase 0 (Briefs): use `references/brief-template.md`.
 - Phase 1 (Collection): use `references/paper-card-schema.md` and `references/license-rules.md`. Dispatch parallel strand agents if multiple briefs exist.
 - Phase 2 (Synthesis): use `references/synthesis-templates.md`. Apply bias rules.
-- Phase 3 (Direction): use `references/direction-paper-template.md`. Delegate prose discipline to `manuscript:manuscript-writing` and review-paper structuring to `manuscript:manuscript-prep`.
+- Phase 3 (Direction): use `references/direction-paper-template.md`. Delegate review-paper IMRAD structuring and prose discipline to `manuscript:manuscript-writing`. Delegate journal LaTeX export to `manuscript:manuscript-formatting`.
 - Phase 4 (Review): invoke `manuscript:paper-review` on the latest direction paper. Disposition each concern (ground / restructure / drop). Loop back as needed.
 
 ### 4. Apply rigor checklist

--- a/plugins/manuscript/skills/lit-review/SKILL.md
+++ b/plugins/manuscript/skills/lit-review/SKILL.md
@@ -25,15 +25,15 @@ Orchestrate a rigorous, citation-grounded literature review across phases: angle
 ## Workflow Phases
 
 ```
-Phase 0: Angles            -> _briefs/strand-*.md (one brief per angle)
-Phase 1: Collection        -> collection/<strand>/<slug>/{card.md, source.{pdf,md}, meta.json}
+Phase 0: Briefs            -> _briefs/strand-*.md (one brief per strand)
+Phase 1: Collection        -> research/collection/<strand>/<slug>/{card.md, source.{pdf,md}, meta.json}
                               + INDEX.md + <strand>.bib per strand
-Phase 2: Synthesis         -> synthesis/{taxonomy,gap-analysis,scope-diagram,map}.md
+Phase 2: Synthesis         -> research/synthesis/{<strand>-ontology, gap-analysis, scope-diagram, <domain>-map}.md
 Phase 3: Direction papers  -> direction-papers/<topic>-direction.md
 Phase 4: Review loop       -> revised direction; may reopen Phase 1 with new gaps
 ```
 
-Iteration is expected. Loop back from any phase. The directory layout is the persistence layer; treat it as the source of truth between sessions.
+Each angle is realized as a strand; the brief is the strand's dispatch document. Iteration is expected: loop back from any phase. The directory layout is the persistence layer; treat it as the source of truth between sessions.
 
 ### Phase 0: Define angles and write briefs
 
@@ -56,24 +56,9 @@ If the user names a project domain (neuro tools, clinical trials, ML methods, et
 
 ### Phase 1: Collection (parallel strand agents)
 
-For each strand, build a corpus of paper-cards. Use `opencite:opencite` for all paper operations.
+For each strand, build a corpus of paper-cards under `research/collection/<strand>/`. Each entry is a folder with `card.md` plus `source.md` plus `meta.json`, and `source.pdf` only when redistributable. Per-strand aggregates are `INDEX.md` and `<strand>.bib`. Use `opencite:opencite` for all paper operations.
 
-Per-entry artifact set (mandatory):
-```
-collection/<strand>/<slug>/
-├── card.md      # paper-card; required; see schema
-├── source.md    # markdown extraction of paper or canonical README; always required
-├── source.pdf   # only when redistribution_ok = true (open access, preprint, repo copy)
-└── meta.json    # provenance: doi, source_url, retrieved_at, license, sha256, redistribution_ok
-```
-
-Per-strand aggregates:
-- `collection/<strand>/INDEX.md` with one-line categorized entries
-- `collection/<strand>/<strand>.bib` with all BibTeX records
-
-Schema reference: [references/paper-card-schema.md](references/paper-card-schema.md).
-
-License-aware archival is non-negotiable. Paywalled PDFs are NOT committed. See [references/license-rules.md](references/license-rules.md). Markdown extractions of paywalled papers are typically committed for research-note fair use, but flag uncertainty in `meta.json.notes`.
+Schema and storage rules: [references/paper-card-schema.md](references/paper-card-schema.md). License-to-redistribution policy and CI rule: [references/license-rules.md](references/license-rules.md).
 
 When parallelizing strands, dispatch one agent per strand. Use the brief as the agent's full context. Do not let strand agents synthesize across strands; that is Phase 2's job.
 
@@ -81,10 +66,10 @@ When parallelizing strands, dispatch one agent per strand. Use the brief as the 
 
 Inputs: full collection across all strands.
 
-Outputs (in `synthesis/`):
+Outputs (in `research/synthesis/`):
 - `<strand>-ontology.md` per strand: hierarchical category tree of corpus entries
-- `science-map.md` (or domain-equivalent): theme-by-theme inventory of analytic / methodological themes
-- `dataset-hierarchy.md` (or domain-equivalent): the data layer
+- `<domain>-map.md` (e.g. `science-map.md`): theme-by-theme inventory of analytic / methodological themes
+- `<data>-hierarchy.md` (e.g. `dataset-hierarchy.md`): the data layer, when applicable
 - `gap-analysis.md`: three-column comparison of what is covered by prior efforts vs. what the synthesis reveals as uncovered. The third column is the input to Phase 3
 - `scope-diagram.md`: prose plus optional Mermaid/ASCII diagram of corpus boundaries
 
@@ -101,10 +86,9 @@ Output: `direction-papers/<topic>-direction.md` per direction (typically one per
 
 Each direction paper:
 - Defends a thesis grounded in the corpus
-- Cites every claim back to a specific card path: `[\`slug\`](../research/collection/<strand>/<slug>/card.md)`
+- Cites every claim back to a specific card path: `[<slug>](../research/collection/<strand>/<slug>/card.md)`
 - Closes with a flat references section keyed to BibTeX in the strand `.bib`
-- Follows review-paper IMRAD structure (delegate structuring to `manuscript:manuscript-prep`)
-- Follows prose discipline (delegate to `manuscript:manuscript-writing`): no em-dashes, abbreviations defined on first use, descriptive voice not exhortatory
+- Follows review-paper IMRAD structure and prose discipline (delegate to `manuscript:manuscript-writing`): no em-dashes, abbreviations defined on first use, descriptive voice not exhortatory
 
 The cite-card cross-link is the load-bearing convention. A claim that does not link to a card is a claim that has not yet been grounded; either ground it (add the card) or remove the claim.
 
@@ -147,8 +131,7 @@ Create directories on demand as work progresses; do not pre-create empty trees. 
 |---|---|
 | `opencite:opencite` | DOI lookup, PDF retrieval, PDF -> markdown, BibTeX export |
 | `opencite:literature-review` | Single-pass thematic synthesis, useful as a Phase 2 seed |
-| `manuscript:manuscript-prep` | IMRAD / review-paper structure for direction papers |
-| `manuscript:manuscript-writing` | Prose discipline (abbreviations, voice, transitions) |
+| `manuscript:manuscript-writing` | IMRAD / review-paper structure plus prose discipline (abbreviations, voice, transitions) |
 | `manuscript:manuscript-formatting` | Journal formatting / LaTeX export |
 | `manuscript:paper-review` | Self-review loops on direction-paper drafts |
 | `project:epic-dev` | Upstream source of research angles when reviewing one's own project |

--- a/plugins/manuscript/skills/lit-review/SKILL.md
+++ b/plugins/manuscript/skills/lit-review/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: lit-review
+description: "Use this skill for \"literature review workflow\", \"multi-phase lit review\", \"direction paper\", \"review paper protocol\", \"strand-based literature review\", \"citation-grounded review\", \"systematic lit review with paper cards\", \"build a lit review corpus\", \"lit review pipeline\", \"orchestrate a literature review\", \"research directions document\", or when the user wants a rigorous multi-phase, citation-traceable literature review with parallel strand collection, taxonomic synthesis, and direction papers (not a single-pass synthesis; for that use opencite:literature-review)."
+version: 0.1.0
+---
+
+# Multi-Phase Literature Review Workflow
+
+Orchestrate a rigorous, citation-grounded literature review across phases: angles to briefs, parallel paper collection, taxonomic synthesis, direction papers, and self-review loops. Every claim in a final document is traceable back to a paper-card.
+
+## When to Use
+
+- Building a corpus-grounded review paper or a set of direction documents
+- Multi-strand reviews where breadth + depth must be coordinated across distinct angles (e.g. tools strand, data strand, science strand)
+- Reviews where claim-to-evidence traceability matters (grant lit reviews, position papers, white papers)
+- Iterative reviews where new papers, refined angles, or updated synthesis must roll forward without losing prior work
+
+## When NOT to Use
+
+- Single-pass thematic synthesis for a manuscript Introduction or Background section. Use `opencite:literature-review` instead.
+- Original research IMRAD writing. Use `manuscript:manuscript-writing`.
+- Peer review of a submitted manuscript. Use `manuscript:paper-review`.
+- Journal formatting. Use `manuscript:manuscript-formatting`.
+
+## Workflow Phases
+
+```
+Phase 0: Angles            -> _briefs/strand-*.md (one brief per angle)
+Phase 1: Collection        -> collection/<strand>/<slug>/{card.md, source.{pdf,md}, meta.json}
+                              + INDEX.md + <strand>.bib per strand
+Phase 2: Synthesis         -> synthesis/{taxonomy,gap-analysis,scope-diagram,map}.md
+Phase 3: Direction papers  -> direction-papers/<topic>-direction.md
+Phase 4: Review loop       -> revised direction; may reopen Phase 1 with new gaps
+```
+
+Iteration is expected. Loop back from any phase. The directory layout is the persistence layer; treat it as the source of truth between sessions.
+
+### Phase 0: Define angles and write briefs
+
+Inputs: prior work, gap statement, epic-dev findings (if any), grant call or thesis question.
+
+Output: one brief per strand in `_briefs/strand-<name>.md`.
+
+Each brief defines:
+- Goal (one sentence)
+- Scope categories (numbered list, breadth first)
+- Per-entry deliverable (cards + source + bib + index)
+- Seed material (existing prior-work documents to import)
+- Acceptance criteria (count thresholds, breadth thresholds, completeness gates)
+- Out-of-scope items
+- Sister skills to use (`opencite:opencite`, `manuscript:manuscript-writing`)
+
+See [references/brief-template.md](references/brief-template.md) for the full structure.
+
+If the user names a project domain (neuro tools, clinical trials, ML methods, etc.), generate strands by partitioning the topic on dimensions that *cannot be merged later without information loss*. Common partitions: methods vs. infrastructure vs. application; tools vs. data vs. theory; modality A vs. modality B.
+
+### Phase 1: Collection (parallel strand agents)
+
+For each strand, build a corpus of paper-cards. Use `opencite:opencite` for all paper operations.
+
+Per-entry artifact set (mandatory):
+```
+collection/<strand>/<slug>/
+├── card.md      # paper-card; required; see schema
+├── source.md    # markdown extraction of paper or canonical README; always required
+├── source.pdf   # only when redistribution_ok = true (open access, preprint, repo copy)
+└── meta.json    # provenance: doi, source_url, retrieved_at, license, sha256, redistribution_ok
+```
+
+Per-strand aggregates:
+- `collection/<strand>/INDEX.md` with one-line categorized entries
+- `collection/<strand>/<strand>.bib` with all BibTeX records
+
+Schema reference: [references/paper-card-schema.md](references/paper-card-schema.md).
+
+License-aware archival is non-negotiable. Paywalled PDFs are NOT committed. See [references/license-rules.md](references/license-rules.md). Markdown extractions of paywalled papers are typically committed for research-note fair use, but flag uncertainty in `meta.json.notes`.
+
+When parallelizing strands, dispatch one agent per strand. Use the brief as the agent's full context. Do not let strand agents synthesize across strands; that is Phase 2's job.
+
+### Phase 2: Synthesis (whole-corpus integration)
+
+Inputs: full collection across all strands.
+
+Outputs (in `synthesis/`):
+- `<strand>-ontology.md` per strand: hierarchical category tree of corpus entries
+- `science-map.md` (or domain-equivalent): theme-by-theme inventory of analytic / methodological themes
+- `dataset-hierarchy.md` (or domain-equivalent): the data layer
+- `gap-analysis.md`: three-column comparison of what is covered by prior efforts vs. what the synthesis reveals as uncovered. The third column is the input to Phase 3
+- `scope-diagram.md`: prose plus optional Mermaid/ASCII diagram of corpus boundaries
+
+Bias rules (enforced):
+- Gap analysis must list *what the corpus does NOT support*, not just what it does
+- Inter-strand contradictions must be named, not papered over
+- Frequency-of-mention is not evidence weight; cite single primary sources where appropriate
+
+See [references/synthesis-templates.md](references/synthesis-templates.md).
+
+### Phase 3: Direction papers (citation-grounded essays)
+
+Output: `direction-papers/<topic>-direction.md` per direction (typically one per strand or per gap cluster).
+
+Each direction paper:
+- Defends a thesis grounded in the corpus
+- Cites every claim back to a specific card path: `[\`slug\`](../research/collection/<strand>/<slug>/card.md)`
+- Closes with a flat references section keyed to BibTeX in the strand `.bib`
+- Follows review-paper IMRAD structure (delegate structuring to `manuscript:manuscript-prep`)
+- Follows prose discipline (delegate to `manuscript:manuscript-writing`): no em-dashes, abbreviations defined on first use, descriptive voice not exhortatory
+
+The cite-card cross-link is the load-bearing convention. A claim that does not link to a card is a claim that has not yet been grounded; either ground it (add the card) or remove the claim.
+
+See [references/direction-paper-template.md](references/direction-paper-template.md).
+
+For LaTeX export of a direction paper to a journal review template, delegate to `manuscript:manuscript-formatting`. The base format is markdown.
+
+### Phase 4: Review loop
+
+Self-review the direction paper using `manuscript:paper-review`. Treat it as a peer review of one's own draft.
+
+Common loop-back triggers:
+- Reviewer (self or other) names a claim as ungrounded -> Phase 1 (add cards) or Phase 3 (drop claim)
+- Reviewer flags a missing theme -> Phase 0 (new strand or expanded scope) -> Phase 1 (collect)
+- Reviewer flags a contradiction in synthesis -> Phase 2 (revise gap analysis or ontology)
+- Reviewer flags storyline incoherence -> Phase 3 (restructure with `manuscript:manuscript-writing`)
+
+Apply [references/rigor-checklist.md](references/rigor-checklist.md) before declaring a direction paper done.
+
+## Bootstrapping a new lit review
+
+When the user starts fresh, propose a top-level layout in the working directory or a subdirectory:
+
+```
+<root>/
+├── _briefs/
+├── research/
+│   ├── collection/
+│   │   ├── _schema/paper-card.md
+│   │   └── <strand>/
+│   └── synthesis/
+└── direction-papers/
+```
+
+Create directories on demand as work progresses; do not pre-create empty trees. The `_schema/paper-card.md` should be a copy of [references/paper-card-schema.md](references/paper-card-schema.md) so that strand agents have a local reference.
+
+## Sister skills
+
+| Skill | Used for |
+|---|---|
+| `opencite:opencite` | DOI lookup, PDF retrieval, PDF -> markdown, BibTeX export |
+| `opencite:literature-review` | Single-pass thematic synthesis, useful as a Phase 2 seed |
+| `manuscript:manuscript-prep` | IMRAD / review-paper structure for direction papers |
+| `manuscript:manuscript-writing` | Prose discipline (abbreviations, voice, transitions) |
+| `manuscript:manuscript-formatting` | Journal formatting / LaTeX export |
+| `manuscript:paper-review` | Self-review loops on direction-paper drafts |
+| `project:epic-dev` | Upstream source of research angles when reviewing one's own project |
+
+## References
+
+- [references/paper-card-schema.md](references/paper-card-schema.md): card.md frontmatter + sections, meta.json schema, license vocabulary, storage rules
+- [references/brief-template.md](references/brief-template.md): per-strand dispatch brief structure
+- [references/synthesis-templates.md](references/synthesis-templates.md): ontology, gap-analysis, map, scope-diagram patterns
+- [references/direction-paper-template.md](references/direction-paper-template.md): essay structure with cite-card cross-link convention
+- [references/license-rules.md](references/license-rules.md): redistribution discipline and CI rules
+- [references/rigor-checklist.md](references/rigor-checklist.md): cohesion, storyline, bias-neutrality, traceability acceptance criteria

--- a/plugins/manuscript/skills/lit-review/references/brief-template.md
+++ b/plugins/manuscript/skills/lit-review/references/brief-template.md
@@ -57,7 +57,6 @@ Imported entries must set `imported_from: <relative path>` in card.md.
 - [ ] >= <N> entries across all <K> categories
 - [ ] Each category has >= <M> entries
 - [ ] Every entry folder has `card.md`, `source.md`, and `meta.json`
-- [ ] `source.pdf` archived for >= 60% of entries with a redistributable paper
 - [ ] All entries have BibTeX in <strand>.bib
 - [ ] INDEX.md fully populated with categorized one-liners
 - [ ] No prose synthesis in this phase; that is Phase 2
@@ -73,5 +72,6 @@ Imported entries must set `imported_from: <relative path>` in card.md.
 
 - The brief is opinionated. Vague briefs produce vague corpora.
 - Numerical thresholds (>= N entries, >= M per category) should be set high enough to force breadth and low enough to ship in one parallel agent run. Typical: N = 20-40, M = 3-6.
+- Sanity-check (not an acceptance criterion): a healthy strand archives `source.pdf` for a meaningful share of entries with redistributable papers. If almost no PDFs are archived, the corpus may have skewed toward paywalled-only sources; consider preprint or AAM alternatives.
 - Seed material is critical. If no prior-work documents exist, the brief must enumerate canonical entries explicitly, otherwise the agent will return a generic survey rather than a thesis-aligned corpus.
 - "Out of scope" lines save more wasted work than any other section. Be specific.

--- a/plugins/manuscript/skills/lit-review/references/brief-template.md
+++ b/plugins/manuscript/skills/lit-review/references/brief-template.md
@@ -1,0 +1,77 @@
+# Strand Brief Template
+
+A brief is the dispatch document for a single strand. It is the only context a parallel collection agent should need.
+
+## File location
+
+`_briefs/strand-<short-name>.md`, e.g. `_briefs/strand-A-tools.md`.
+
+## Structure
+
+```markdown
+# Strand <X>, <Strand Title> (Phase 1 brief)
+
+**Goal:** populate `research/collection/<strand>/` with at least <N> paper-cards covering <topic>.
+
+## Scope
+
+Cover <K> categories. Aim for breadth first, depth where it matters for the thesis.
+
+### 1. <Category 1>
+- <Bullet seed list of canonical works, tools, datasets, or standards>
+- <Include explicit names, version pins where helpful>
+
+### 2. <Category 2>
+- ...
+
+### <K>. <Category K>
+- ...
+
+## Per-entry deliverable
+
+Create folder `research/collection/<strand>/<slug>/` containing:
+- `card.md` from the schema (`type` ∈ {paper, dataset, tool, platform, standard}; `strand: <strand>`)
+- `source.pdf` only if redistributable (open access, preprint, repo copy)
+- `source.md` always required; markdown extraction or canonical README
+- `meta.json` with provenance (DOI / URL, retrieved_at, license, sha256 if PDF archived, redistribution_ok)
+- BibTeX entry appended to `research/collection/<strand>/<strand>.bib`
+- One-line entry in `research/collection/<strand>/INDEX.md` under the right category heading
+
+Use `opencite:opencite` for DOI lookup, PDF retrieval (where licensing permits), and PDF -> markdown conversion.
+
+## Seed material
+
+<Point to existing prior-work documents the agent should mine for entries, e.g.>
+- `<path/to/existing-lit-review.md>`
+- `<path/to/grant-strategy.tex>`
+
+Imported entries must set `imported_from: <relative path>` in card.md.
+
+## Skills to use
+
+- `opencite:opencite` for paper retrieval, DOI lookup, BibTeX export
+- `manuscript:manuscript-writing` for prose discipline (no em-dashes, abbreviations on first use)
+
+## Acceptance criteria
+
+- [ ] >= <N> entries across all <K> categories
+- [ ] Each category has >= <M> entries
+- [ ] Every entry folder has `card.md`, `source.md`, and `meta.json`
+- [ ] `source.pdf` archived for >= 60% of entries with a redistributable paper
+- [ ] All entries have BibTeX in <strand>.bib
+- [ ] INDEX.md fully populated with categorized one-liners
+- [ ] No prose synthesis in this phase; that is Phase 2
+
+## Out of scope
+
+- <Topics adjacent but outside the thesis>
+- Drafting the direction paper or other synthesis prose
+- Comparing or ranking entries; collection only
+```
+
+## Authoring notes
+
+- The brief is opinionated. Vague briefs produce vague corpora.
+- Numerical thresholds (>= N entries, >= M per category) should be set high enough to force breadth and low enough to ship in one parallel agent run. Typical: N = 20-40, M = 3-6.
+- Seed material is critical. If no prior-work documents exist, the brief must enumerate canonical entries explicitly, otherwise the agent will return a generic survey rather than a thesis-aligned corpus.
+- "Out of scope" lines save more wasted work than any other section. Be specific.

--- a/plugins/manuscript/skills/lit-review/references/direction-paper-template.md
+++ b/plugins/manuscript/skills/lit-review/references/direction-paper-template.md
@@ -11,7 +11,7 @@ A direction paper is a focused, citation-rich essay that defends a thesis, surve
 ```markdown
 # <Strand or Topic> Direction, <Headline Thesis>
 
-A focused review on the <strand> strand of <project>. <One-paragraph thesis statement that names what is missing in the literature and what this paper argues should fill the gap.> The argument was first articulated in <upstream issue or prior-work pointer>; this paper develops it into a literature-grounded position by surveying the <K> themes catalogued in the Phase 1 corpus and the Phase 2 [`<map>`](../research/synthesis/<map>.md).
+A focused review on the <strand> strand of <project>. <One-paragraph thesis statement that names what is missing in the literature and what this paper argues should fill the gap.> The argument was first articulated in <upstream issue or prior-work pointer>; this paper develops it into a literature-grounded position by surveying the <K> themes catalogued in the Phase 1 corpus and the Phase 2 [`<domain>-map`](../research/synthesis/<domain>-map.md).
 
 Abbreviations: <Define every abbreviation on first use, comma-separated, in this paragraph.>
 
@@ -24,7 +24,7 @@ Abbreviations: <Define every abbreviation on first use, comma-separated, in this
 
 ### 1.2 Gap statement
 
-<1-2 paragraphs naming what is missing. Anchor the gap with citations to corpus cards. Mirror the gap as it appears in synthesis/gap-analysis.md, do not invent a new framing.>
+<1-2 paragraphs naming what is missing. Anchor the gap with citations to corpus cards. Mirror the gap as it appears in `../research/synthesis/gap-analysis.md`, do not invent a new framing.>
 
 ### 1.3 Thesis
 
@@ -32,7 +32,7 @@ Abbreviations: <Define every abbreviation on first use, comma-separated, in this
 
 ## 2. Background, the <K> themes
 
-The Phase 1 corpus organizes <N> entries into <K> themes; the Phase 2 [`<map>`](../research/synthesis/<map>.md) inventories each theme. This section summarizes the prior-work landscape that the rest of the paper draws on.
+The Phase 1 corpus organizes <N> entries into <K> themes; the Phase 2 [`<domain>-map`](../research/synthesis/<domain>-map.md) inventories each theme. This section summarizes the prior-work landscape that the rest of the paper draws on.
 
 **Theme 1, <name>.** <2-4 sentence summary citing card paths: [<slug>](../research/collection/<strand>/<slug>/card.md).>
 
@@ -56,11 +56,11 @@ The Phase 1 corpus organizes <N> entries into <K> themes; the Phase 2 [`<map>`](
 
 ## 5. Roadmap
 
-<Phased commitments derived from gap-analysis.md. Each commitment names the artifacts it would produce.>
+<Phased commitments derived from `../research/synthesis/gap-analysis.md`. Each commitment names the artifacts it would produce.>
 
 ## 6. Coordination with adjacent efforts
 
-<How this direction relates to ANNOTATE R01 / sister grants / parallel labs. Cite cards or external pointers.>
+<How this direction relates to sister grants, parallel labs, or adjacent efforts. Cite cards or external pointers.>
 
 ## 7. Discussion
 
@@ -107,7 +107,7 @@ Apply `manuscript:manuscript-writing`:
 
 - No em-dashes; commas or semicolons.
 - Abbreviations defined on first use within the document. The Abbreviations paragraph after the thesis is the canonical first-use site.
-- Descriptive voice, not exhortatory. "AGI argues" rather than "AGI must"; "the corpus reveals" rather than "we should".
+- Descriptive voice, not exhortatory. "<Project> argues" rather than "<Project> must"; "the corpus reveals" rather than "we should".
 - Active voice for actions the paper takes. Past tense for what prior work did.
 - One idea per sentence. Topic sentence then evidence then interpretation per paragraph.
 

--- a/plugins/manuscript/skills/lit-review/references/direction-paper-template.md
+++ b/plugins/manuscript/skills/lit-review/references/direction-paper-template.md
@@ -1,0 +1,141 @@
+# Direction Paper Template
+
+A direction paper is a focused, citation-rich essay that defends a thesis, surveys the landscape, and proposes a roadmap. One per strand or per gap cluster.
+
+## File location
+
+`direction-papers/<topic>-direction.md`.
+
+## Structure
+
+```markdown
+# <Strand or Topic> Direction, <Headline Thesis>
+
+A focused review on the <strand> strand of <project>. <One-paragraph thesis statement that names what is missing in the literature and what this paper argues should fill the gap.> The argument was first articulated in <upstream issue or prior-work pointer>; this paper develops it into a literature-grounded position by surveying the <K> themes catalogued in the Phase 1 corpus and the Phase 2 [`<map>`](../research/synthesis/<map>.md).
+
+Abbreviations: <Define every abbreviation on first use, comma-separated, in this paragraph.>
+
+## 1. Introduction
+
+### 1.1 The arc
+
+<2-4 paragraphs locating the topic historically. Cite the establishing works:>
+[<slug>](../research/collection/<strand>/<slug>/card.md), [<slug>](...).
+
+### 1.2 Gap statement
+
+<1-2 paragraphs naming what is missing. Anchor the gap with citations to corpus cards. Mirror the gap as it appears in synthesis/gap-analysis.md, do not invent a new framing.>
+
+### 1.3 Thesis
+
+<1 paragraph articulating the direction this paper argues for. State the structure of the remainder.>
+
+## 2. Background, the <K> themes
+
+The Phase 1 corpus organizes <N> entries into <K> themes; the Phase 2 [`<map>`](../research/synthesis/<map>.md) inventories each theme. This section summarizes the prior-work landscape that the rest of the paper draws on.
+
+**Theme 1, <name>.** <2-4 sentence summary citing card paths: [<slug>](../research/collection/<strand>/<slug>/card.md).>
+
+**Theme 2, <name>.** <...>
+
+...
+
+## 3. <Argument body>
+
+### 3.1 <Argument node 1>
+
+<Each subsection advances one beat of the thesis. Every claim cites a card path. Counter-evidence is named, not omitted.>
+
+### 3.2 <Argument node 2>
+
+...
+
+## 4. <Existence proof or anchor case>
+
+<One concrete case from the corpus that demonstrates the thesis is buildable. Cite the card.>
+
+## 5. Roadmap
+
+<Phased commitments derived from gap-analysis.md. Each commitment names the artifacts it would produce.>
+
+## 6. Coordination with adjacent efforts
+
+<How this direction relates to ANNOTATE R01 / sister grants / parallel labs. Cite cards or external pointers.>
+
+## 7. Discussion
+
+### 7.1 Interpretation
+
+<What the direction paper changes about the field if adopted.>
+
+### 7.2 Limitations
+
+<Honest limitations. What corpus entries do not support this thesis? Name them.>
+
+### 7.3 Counterarguments
+
+<Steelman the strongest objection. Cite the cards that ground the objection. Then respond.>
+
+## 8. Conclusion
+
+<1-2 paragraphs.>
+
+## References
+
+<Flat list keyed to the strand .bib. One entry per BibTeX key, in the order first cited or alphabetical, by convention.>
+```
+
+## The cite-card cross-link convention
+
+Every concrete claim in a direction paper must include a cross-link of the form:
+
+```markdown
+[<slug>](../research/collection/<strand>/<slug>/card.md)
+```
+
+This is the load-bearing convention. It serves three purposes:
+
+1. **Traceability**: a reader (or a later self) can land on the card and check the claim against `source.md`.
+2. **Falsifiability**: a claim that does not link to a card has not yet been grounded. Either ground it (add a card) or drop it.
+3. **Bias hygiene**: links force engagement with the actual corpus instead of the author's prior beliefs.
+
+A direction paper is *complete* when every paragraph contains at least one cross-link to a card, and every cited card actually supports the claim.
+
+## Style discipline
+
+Apply `manuscript:manuscript-writing`:
+
+- No em-dashes; commas or semicolons.
+- Abbreviations defined on first use within the document. The Abbreviations paragraph after the thesis is the canonical first-use site.
+- Descriptive voice, not exhortatory. "AGI argues" rather than "AGI must"; "the corpus reveals" rather than "we should".
+- Active voice for actions the paper takes. Past tense for what prior work did.
+- One idea per sentence. Topic sentence then evidence then interpretation per paragraph.
+
+## Length guide
+
+| Section | Target |
+|---|---|
+| Introduction (1) | 1.5-3 pages |
+| Background (2) | 2-4 pages |
+| Argument (3) | 4-7 pages |
+| Anchor case (4) | 1-2 pages |
+| Roadmap (5) | 1-2 pages |
+| Coordination (6) | 1 page |
+| Discussion (7) | 2-3 pages |
+| Conclusion (8) | 0.5 page |
+
+Total target: 12-22 pages of dense markdown, before the References section.
+
+## When the paper feels unfinished
+
+Diagnostic checklist:
+
+- A section reads as opinion rather than synthesis -> add card cross-links to ground each beat.
+- The argument cites the same 3-4 cards repeatedly -> corpus is too narrow; loop to Phase 1.
+- Counterarguments section is generic -> read the cards tagged as contrary; the strongest objection is in there.
+- Roadmap reads as wish list -> tie each commitment to a specific gap from gap-analysis.md.
+- Storyline does not flow -> apply `manuscript:manuscript-writing` revision pass focused on transitions and topic sentences.
+
+## Export to LaTeX
+
+Markdown is the base format. To export for a journal review template, delegate to `manuscript:manuscript-formatting` with the target journal. Cite-card cross-links typically convert to footnotes or in-text citations against the strand `.bib`.

--- a/plugins/manuscript/skills/lit-review/references/license-rules.md
+++ b/plugins/manuscript/skills/lit-review/references/license-rules.md
@@ -1,0 +1,86 @@
+# License-Aware Archival Rules
+
+The lit-review corpus must be redistributable. PDFs are committed only when the license permits. Markdown extractions are typically committed under research-note fair use.
+
+## The single source of truth
+
+`meta.json.redistribution_ok` (boolean) is the authoritative flag. Every other rule derives from it.
+
+| `redistribution_ok` | `source.pdf` allowed in repo? | `source.md` allowed in repo? |
+|---|---|---|
+| `true`  | yes; populate `pdf_sha256`         | yes |
+| `false` | no; `pdf_path: null`, `pdf_sha256: null` | yes; flag uncertainty in `notes` if extraction is borderline |
+
+## License vocabulary and redistribution mapping
+
+| `pdf_license` value | `redistribution_ok` |
+|---|---|
+| `CC-BY`, `CC-BY-2.0`, `CC-BY-3.0`, `CC-BY-4.0` | true |
+| `CC0` | true |
+| `CC-BY-NC` | true (research use; document non-commercial in `notes`) |
+| `preprint-cc-arxiv`, `preprint-cc-biorxiv`, `preprint-cc-osf` | true |
+| `author-accepted-manuscript` | true; document the institutional repository in `notes` |
+| `publisher-paywall` | false |
+| `publisher-paywall (<journal>); university repository copy archived` | true (the AAM is what is archived; document in `notes`) |
+| `not-applicable` | true (no PDF; tool/dataset card) |
+| `unknown` | false (default deny) |
+
+When in doubt, default to `false`. Re-archiving is cheap; takedown notices are not.
+
+## Source preference order
+
+For each entry, prefer in order:
+
+1. **Open-access publisher copy** (CC-BY journal, eLife, PLOS, Frontiers).
+2. **Preprint** (arXiv, bioRxiv, OSF). Note the relationship to the published version in `notes`.
+3. **Author Accepted Manuscript** in an institutional repository.
+4. **Markdown extraction only**, no PDF (paywalled with no preprint).
+
+If the only available copy is paywalled with no preprint or AAM, set `pdf_status: not-redistributable`, `pdf_path: null`, and store the markdown extraction.
+
+## Markdown extractions of paywalled papers
+
+Storing a markdown extraction (text only, no figures, no original layout) of a paywalled paper is generally accepted under research-note fair use across US, EU, and UK academic norms. However:
+
+- Document the source in `meta.json.notes`: "extracted from paywalled <journal> PDF, used as research notes only".
+- Do not commit the original PDF.
+- Do not reproduce figures from the paywalled paper. Reference them by figure number and citation.
+- If the rights holder requests removal, comply. Track such requests in a top-level `LICENSE-NOTES.md` if they accumulate.
+- For papers under aggressive paywalls (e.g. publisher with active anti-circumvention enforcement), consider linking to the publisher landing page and citing without storing the markdown.
+
+## Storage rules summary
+
+- **Open-access PDF available**: commit `source.pdf` and `source.md`. `redistribution_ok: true`. Populate `pdf_sha256`.
+- **Preprint available, no published OA**: commit the preprint as `source.pdf` and `source.md`. Note the relationship in `notes`.
+- **AAM in institutional repository**: commit the AAM as `source.pdf` and `source.md`. Document the repository URL in `notes`.
+- **Paywalled with no OA / preprint / AAM**: do NOT commit PDF. Commit `source.md`. `redistribution_ok: false`.
+- **Tool / dataset / standard with no paper**: snapshot README or canonical landing as `source.md`. `pdf_status: not-applicable`. `redistribution_ok: true` (READMEs are typically permissively licensed; document in `notes`).
+- **Failed download**: set `pdf_status: not-available`. Document failure mode (Cloudflare, broken DOI, reCAPTCHA, etc.) in `notes`. Re-attempt later.
+
+## CI rule
+
+Recommended invariant for the corpus repository (enforce in CI):
+
+> If `meta.json.redistribution_ok == false`, then no `source.pdf` file may exist in the entry folder.
+
+A simple shell check:
+
+```bash
+for entry in research/collection/*/*/; do
+  redistribution_ok=$(jq -r '.redistribution_ok' "$entry/meta.json" 2>/dev/null)
+  if [[ "$redistribution_ok" == "false" && -f "$entry/source.pdf" ]]; then
+    echo "VIOLATION: $entry has source.pdf but redistribution_ok=false"
+    exit 1
+  fi
+done
+```
+
+Add this to the pre-commit hook or CI workflow if the corpus is on GitHub.
+
+## When a license changes
+
+Open-access publishers occasionally re-license content. Preprint servers do not. If a previously open-access journal becomes paywalled retroactively for old content (rare), the existing committed PDFs are protected by the license active at retrieval time. Document `retrieved_at` in `meta.json` so the licensing context is preserved.
+
+## When in doubt
+
+Ask the rights holder (publisher, repository, author). If the answer is unclear, store the markdown only and set `redistribution_ok: false`.

--- a/plugins/manuscript/skills/lit-review/references/paper-card-schema.md
+++ b/plugins/manuscript/skills/lit-review/references/paper-card-schema.md
@@ -1,0 +1,132 @@
+# Paper-Card Schema
+
+Each entry lives in its own folder under the strand:
+
+```
+research/collection/<strand>/<slug>/
+├── card.md         this paper-card; required
+├── source.pdf      full PDF; only when redistributable
+├── source.md       markdown extraction or canonical README; always required
+└── meta.json       provenance: source URL, retrieval date, license, hash, redistribution flag
+```
+
+Rationale: synthesis and direction-paper drafting must be able to re-read primary text without re-fetching. Summaries are derived; sources are persisted.
+
+## card.md template
+
+```yaml
+---
+slug: <kebab-case-short-id>             # matches folder name
+type: paper | dataset | tool | platform | standard
+strand: <strand-name>                   # matches the parent folder
+year: <YYYY>
+authors: [<surname1>, <surname2>, ...]
+venue: <journal / conference / org>
+doi: <doi or null>
+url: <canonical url or null>
+license: <license or null>
+modalities: [<domain-specific tags>]
+tags: [<5-12 short tags>]
+relevance: high | medium | low
+imported_from: <relative path or null>
+added: <YYYY-MM-DD>
+
+# Archival fields
+pdf_status: archived | not-redistributable | not-available | not-applicable
+pdf_path: source.pdf | null
+md_path: source.md | null
+md_quality: clean | rough | partial | abstract-only
+---
+```
+
+### relevance calibration anchors
+
+To keep the field discriminative for downstream filtering:
+
+- **high**: direct dependency for the project's deliverables. The thing the work is built on or against.
+- **medium**: standard within scope but not a direct dependency. Context that informs but does not constrain.
+- **low**: tangential or background. Reference-only.
+
+If more than ~40% of entries land in `high`, the field has lost discriminative power. Rebalance.
+
+### Sections
+
+- **TL;DR**: one or two sentences capturing the *thesis*, not duplicating the Summary opening.
+- **Summary**: 3-6 sentences covering core contribution, method, scope, key numbers.
+- **Relevance to the review**: concrete connection to the project / thesis. Cite specific mechanisms or claims. Avoid generic prose.
+- **Notable details**: bullet list of facts worth pulling forward to synthesis.
+- **Open questions / limitations**: paper-specific only. Phase 2 gap analysis depends on this; generic boilerplate is harmful.
+- **Citations**: primary BibTeX key plus up to 5 related works as one-liners.
+
+## meta.json template
+
+```json
+{
+  "doi": "10.xxxx/xxxxx",
+  "source_url": "https://...",
+  "retrieved_at": "YYYY-MM-DD",
+  "pdf_sha256": "<sha256 hex if archived; null otherwise>",
+  "pdf_license": "<see vocabulary below>",
+  "redistribution_ok": true,
+  "notes": "<retrieval notes, e.g. 'arXiv preprint used; published version paywalled'>"
+}
+```
+
+### pdf_license vocabulary
+
+- `CC-BY`, `CC-BY-2.0`, `CC-BY-3.0`, `CC-BY-4.0`, `CC-BY-NC`, `CC0`
+- `preprint-cc-arxiv`, `preprint-cc-biorxiv`, `preprint-cc-osf`
+- `author-accepted-manuscript` (institutional repository copy)
+- `publisher-paywall`
+- `not-applicable` (e.g. tool with only a README)
+- `unknown`
+
+Values may include a parenthetical qualifier when needed, e.g. `publisher-paywall (NeuroImage); university repository copy archived`.
+
+`redistribution_ok` must align with the license. Any `*-paywall` value implies `redistribution_ok: false`.
+
+## Storage rules
+
+- **Open-access PDFs** (CC-BY, CC0, arXiv, bioRxiv, OSF, institutional repository): commit under `source.pdf`; populate `pdf_sha256`.
+- **Paywalled / non-redistributable**: do NOT commit the PDF. Set `pdf_status: not-redistributable`, `pdf_path: null`, `pdf_sha256: null`. Still commit `source.md`; flag uncertainty about extraction in `notes`.
+- **Datasets / tools without a paper**: set `pdf_status: not-applicable`. Store the project README or canonical landing page as `source.md`.
+- **Failed downloads**: set `pdf_status: not-available`. Document the failure mode in `notes` (Cloudflare gate, broken DOI, paywall without preprint, etc.).
+
+The `redistribution_ok` field is the single source of truth for whether `source.pdf` may exist in the repo. CI for the corpus should enforce: `redistribution_ok: false` implies no `source.pdf` file in the entry folder.
+
+## INDEX.md per strand
+
+Plain markdown index, grouped by category, one line per entry:
+
+```markdown
+# <Strand name> Collection Index
+
+## Category 1
+- [<slug>](./<slug>/card.md): one-line description (`relevance: high`, year)
+
+## Category 2
+- ...
+```
+
+## .bib per strand
+
+Append the BibTeX returned by `opencite` for each entry:
+
+```bibtex
+@article{slug2024key,
+  ...
+}
+```
+
+Keep the citation key consistent with the slug where possible.
+
+## Tooling
+
+Use `opencite:opencite` to:
+
+1. Resolve DOI / canonical URL
+2. Download PDF where licensing permits
+3. Convert PDF to markdown (`source.md`)
+4. Export BibTeX
+
+For tools or platforms without papers, snapshot the canonical README / docs landing as `source.md`. Link the repo URL in `meta.json.source_url`.

--- a/plugins/manuscript/skills/lit-review/references/paper-card-schema.md
+++ b/plugins/manuscript/skills/lit-review/references/paper-card-schema.md
@@ -87,12 +87,14 @@ Values may include a parenthetical qualifier when needed, e.g. `publisher-paywal
 
 ## Storage rules
 
-- **Open-access PDFs** (CC-BY, CC0, arXiv, bioRxiv, OSF, institutional repository): commit under `source.pdf`; populate `pdf_sha256`.
-- **Paywalled / non-redistributable**: do NOT commit the PDF. Set `pdf_status: not-redistributable`, `pdf_path: null`, `pdf_sha256: null`. Still commit `source.md`; flag uncertainty about extraction in `notes`.
-- **Datasets / tools without a paper**: set `pdf_status: not-applicable`. Store the project README or canonical landing page as `source.md`.
-- **Failed downloads**: set `pdf_status: not-available`. Document the failure mode in `notes` (Cloudflare gate, broken DOI, paywall without preprint, etc.).
+The `pdf_status` enum semantics are:
 
-The `redistribution_ok` field is the single source of truth for whether `source.pdf` may exist in the repo. CI for the corpus should enforce: `redistribution_ok: false` implies no `source.pdf` file in the entry folder.
+- `archived`: `source.pdf` is committed; `pdf_sha256` populated. Used when `redistribution_ok: true` and a PDF is available.
+- `not-redistributable`: paywalled or otherwise non-redistributable. `pdf_path: null`, `pdf_sha256: null`. `source.md` is still committed.
+- `not-applicable`: no paper exists (tool / dataset / standard with only a README). `source.md` is the snapshot.
+- `not-available`: download failed. Document the failure mode in `meta.json.notes` and re-attempt later.
+
+The `redistribution_ok` field is the single source of truth for whether `source.pdf` may exist in the repo. License-to-redistribution policy and the CI rule live in [license-rules.md](license-rules.md).
 
 ## INDEX.md per strand
 

--- a/plugins/manuscript/skills/lit-review/references/rigor-checklist.md
+++ b/plugins/manuscript/skills/lit-review/references/rigor-checklist.md
@@ -1,0 +1,98 @@
+# Rigor Checklist
+
+Apply before declaring a phase done. The checklist is per-phase; do not skip ahead.
+
+## Phase 0: Briefs
+
+- [ ] One brief per strand, in `_briefs/strand-<name>.md`.
+- [ ] Strands partition the topic on a dimension that cannot be merged later (methods vs. data, tools vs. theory, modality vs. modality).
+- [ ] Each brief has explicit scope categories (numbered list), per-entry deliverable, seed material, acceptance criteria, and out-of-scope items.
+- [ ] Acceptance criteria are quantified: minimum entry count overall and per category.
+- [ ] No prose synthesis is implied by the brief; collection only.
+
+## Phase 1: Collection
+
+- [ ] Per-entry artifact set complete: `card.md`, `source.md`, `meta.json`. `source.pdf` iff `redistribution_ok: true`.
+- [ ] Every entry's `card.md` has all required frontmatter fields populated, no nulls except where allowed.
+- [ ] `relevance` is calibrated: less than ~40% of entries are `high`.
+- [ ] `INDEX.md` per strand is fully populated, grouped by category.
+- [ ] `<strand>.bib` has a BibTeX record for every entry.
+- [ ] License rules are not violated: no `source.pdf` exists where `redistribution_ok: false`.
+- [ ] Acceptance thresholds from the brief are met (entry count overall and per category).
+- [ ] No cross-strand synthesis has crept in; cards summarize one work each.
+
+## Phase 2: Synthesis
+
+- [ ] One ontology per strand in `synthesis/<strand>-ontology.md`. Each leaf links to a card.
+- [ ] Domain map (`<domain>-map.md`) inventories themes; each theme cites establishing cards and lists open questions.
+- [ ] Data hierarchy or domain equivalent if applicable.
+- [ ] `gap-analysis.md` is three-column with the third column as the load-bearing one. Gap count exceeds the brief's bar.
+- [ ] Each gap is established by listing the cards that collectively define the negative space.
+- [ ] Inter-strand contradictions are named in the map under "Open questions", not flattened into gaps.
+- [ ] `scope-diagram.md` states in-scope and adjacent-out-of-scope explicitly, with rationale for exclusions.
+- [ ] Every concrete claim in synthesis prose cites a card path. No ungrounded assertions.
+
+## Phase 3: Direction papers
+
+- [ ] One direction paper per strand or per gap cluster, in `direction-papers/<topic>-direction.md`.
+- [ ] Headline thesis is articulated in the opening paragraph and the Introduction.
+- [ ] Every concrete claim includes a cite-card cross-link of the form `[<slug>](../research/collection/<strand>/<slug>/card.md)`.
+- [ ] Every paragraph in argument sections (3, 4, 5) contains at least one cite-card cross-link.
+- [ ] Every cited card actually supports the claim. Spot-check by clicking through and reading the card's TL;DR and Notable details sections.
+- [ ] Counterargument section is corpus-grounded, not generic. The strongest objection is named with cite-card links.
+- [ ] Roadmap commitments tie to specific gaps in `gap-analysis.md`.
+- [ ] Style discipline is enforced: no em-dashes; abbreviations defined on first use in the Abbreviations paragraph; descriptive voice not exhortatory.
+- [ ] References section is keyed to the strand `.bib`.
+
+## Phase 4: Review loop
+
+- [ ] Self-review pass via `manuscript:paper-review` is recorded as comments or a sibling review document.
+- [ ] Each reviewer concern is dispositioned: ground (Phase 1), restructure (Phase 2 or 3), or drop (Phase 3 with explicit removal).
+- [ ] Loop-backs are atomic: a single concern produces a single revision pass; do not bundle revisions across concerns until the final polish.
+- [ ] After the final revision pass, re-run Phase 3 checklist completely.
+
+## Whole-project quality gates
+
+These are the gates that distinguish a rigorous review from a pretty one.
+
+### Traceability
+
+Pick five claims at random from the direction paper. For each:
+
+- [ ] Click the cite-card link. Does the card load?
+- [ ] Does the card's TL;DR or Summary support the claim?
+- [ ] Does `source.md` (or `source.pdf` if redistributable) actually contain the supporting text?
+
+If any of the three fails, the claim is ungrounded. Fix it.
+
+### Storyline cohesion
+
+Read the direction paper section openings only (Section 1.1, 1.2, ..., 7.1, 7.2, 8). 
+
+- [ ] Do the section openings, read in order, narrate a coherent argument?
+- [ ] Does each section's opening reference what the prior section established?
+- [ ] Is there a single thesis sentence that the whole paper drives toward, recoverable from reading openings only?
+
+If reading openings only yields fragments rather than an argument, restructure with `manuscript:manuscript-writing`.
+
+### Bias balance
+
+- [ ] Counterargument section names the strongest objection, not a strawman.
+- [ ] Limitations section names corpus entries that do not support the thesis (not just generic methodological caveats).
+- [ ] Gap analysis lists what the corpus does NOT support. Frequency-of-mention is not weight.
+- [ ] If results favor the thesis on every dimension, the corpus is probably too small or too aligned. Loop to Phase 1 and add adversarial entries.
+
+### Reproducibility
+
+- [ ] A reader who clones the corpus and reads `_briefs/`, `INDEX.md`, `synthesis/`, and `direction-papers/` in order can reconstruct the argument without further context.
+- [ ] No load-bearing claims live only in conversation history or scratch notes. Persist them to the layout.
+
+## Final acceptance
+
+The review is done when:
+
+- All Phase 3 checks pass.
+- All whole-project quality gates pass.
+- The user (or self) has read the direction paper end to end and would defend each cite-card link in a hostile review.
+
+Anything less is a draft, not a release.

--- a/plugins/manuscript/skills/lit-review/references/rigor-checklist.md
+++ b/plugins/manuscript/skills/lit-review/references/rigor-checklist.md
@@ -23,7 +23,7 @@ Apply before declaring a phase done. The checklist is per-phase; do not skip ahe
 
 ## Phase 2: Synthesis
 
-- [ ] One ontology per strand in `synthesis/<strand>-ontology.md`. Each leaf links to a card.
+- [ ] One ontology per strand in `research/synthesis/<strand>-ontology.md`. Each leaf links to a card.
 - [ ] Domain map (`<domain>-map.md`) inventories themes; each theme cites establishing cards and lists open questions.
 - [ ] Data hierarchy or domain equivalent if applicable.
 - [ ] `gap-analysis.md` is three-column with the third column as the load-bearing one. Gap count exceeds the brief's bar.
@@ -84,7 +84,7 @@ If reading openings only yields fragments rather than an argument, restructure w
 
 ### Reproducibility
 
-- [ ] A reader who clones the corpus and reads `_briefs/`, `INDEX.md`, `synthesis/`, and `direction-papers/` in order can reconstruct the argument without further context.
+- [ ] A reader who clones the corpus and reads `_briefs/`, `research/collection/<strand>/INDEX.md`, `research/synthesis/`, and `direction-papers/` in order can reconstruct the argument without further context.
 - [ ] No load-bearing claims live only in conversation history or scratch notes. Persist them to the layout.
 
 ## Final acceptance

--- a/plugins/manuscript/skills/lit-review/references/synthesis-templates.md
+++ b/plugins/manuscript/skills/lit-review/references/synthesis-templates.md
@@ -1,0 +1,129 @@
+# Synthesis Templates
+
+Phase 2 outputs live in `research/synthesis/`. Each document integrates the full corpus across strands. Synthesis is bias-disciplined: gaps are stated explicitly, contradictions are named, frequency is not weight.
+
+## File set
+
+| File | Purpose | Required? |
+|---|---|---|
+| `<strand>-ontology.md` | Hierarchical category tree per strand (one file per strand) | Yes |
+| `<domain>-map.md` | Theme-by-theme inventory of analytic / methodological themes | Yes |
+| `<data>-hierarchy.md` | The data layer (datasets, modalities, sample sizes); rename per domain | Iff strand has data |
+| `gap-analysis.md` | Three-column accounting: prior-effort coverage, current-thesis coverage, uncovered scope | Yes |
+| `scope-diagram.md` | Prose plus optional Mermaid/ASCII diagram of corpus boundaries | Yes |
+
+## Ontology template
+
+```markdown
+# <Strand> Ontology
+
+A hierarchical view of the <strand> corpus. Each entry links to its paper-card.
+
+## Top-level categories
+
+### Category A: <name>
+- Sub-category A.1: <name>
+  - [<slug>](../collection/<strand>/<slug>/card.md): one-line role statement
+  - ...
+- Sub-category A.2: <name>
+  - ...
+
+### Category B: <name>
+- ...
+
+## Cross-cutting tags
+
+Tags that apply across categories (e.g. open-source, deprecated, paywalled, GPU-required):
+- `<tag>`: [<slug>](../collection/<strand>/<slug>/card.md), ...
+```
+
+Sub-category leaves should not duplicate the brief's category headings; the ontology is allowed to refactor categories as the corpus reveals natural joints.
+
+## Map template (theme-by-theme inventory)
+
+```markdown
+# <Domain> Map
+
+Theme-by-theme inventory of the analytic and methodological themes the corpus addresses. Each theme cites the establishing paper-cards.
+
+## Theme 1: <name>
+
+**Defining works**: [<slug>](../collection/<strand>/<slug>/card.md), [<slug>](...).
+
+<2-4 sentence prose summary of the theme: what it studies, what method, what scope.>
+
+**Open questions**: <named questions the corpus surfaces but does not answer. These feed gap-analysis.>
+
+## Theme 2: <name>
+
+...
+```
+
+The map is the connective tissue between collection and direction papers. A direction paper that does not draw on the map is probably ungrounded; a theme in the map that no direction paper draws on is probably noise.
+
+## Gap analysis template
+
+Three-column structure. The third column is the load-bearing one.
+
+```markdown
+# Gap Analysis
+
+| Topic | <Prior effort A> covers | <Prior effort B> covers | Uncovered, our distinctive scope |
+|---|---|---|---|
+| <Topic 1> | <coverage> | <coverage> | <gap> |
+| <Topic 2> | <coverage> | <coverage> | <gap> |
+| ... | ... | ... | ... |
+
+## Concrete gap list
+
+### Gap 1: <name>
+
+**Established by**: [<slug>](../collection/<strand>/<slug>/card.md), [<slug>](...).
+
+<2-3 sentence prose: what the corpus reveals as missing, why it matters.>
+
+**Proposed Phase 3 commitment**: <what the direction paper will say about this gap.>
+
+### Gap 2: <name>
+
+...
+```
+
+Bias rules:
+
+1. **Gaps are about absence, not preference.** "We could do X" is not a gap; "the corpus does not contain a single entry that does X" is a gap.
+2. **Cite the absence.** A gap is established by listing the cards that establish the boundary; the gap itself is the negative space those cards collectively define.
+3. **Acceptance bar exceeds the brief.** If the brief asked for >= 5 gaps, the synthesis should return >= 6-8. Phase 3 will prioritize.
+4. **Contradictions are not gaps.** When two corpus entries disagree, name the contradiction in the map under "Open questions"; do not flatten it into a gap.
+
+## Scope diagram template
+
+```markdown
+# Scope Diagram
+
+A prose-plus-diagram statement of what this corpus covers and what it deliberately excludes.
+
+## In scope
+
+- <Topic>: covered by <N> entries across <strand A> and <strand B>
+- ...
+
+## Adjacent but out of scope
+
+- <Topic>: explicitly out of scope per [brief A](../_briefs/strand-A.md) and [brief B](../_briefs/strand-B.md). Rationale: <why>.
+- ...
+
+## Boundaries diagram
+
+```
+<ASCII or Mermaid diagram showing nested or overlapping scopes>
+```
+```
+
+If using Mermaid, prefer `flowchart TD` or `mindmap`. Keep it under 30 nodes; otherwise the diagram has stopped being a summary.
+
+## Authoring discipline
+
+- Synthesis prose follows `manuscript:manuscript-writing` discipline: no em-dashes, abbreviations defined on first use, descriptive voice not exhortatory.
+- Every concrete claim cites a card path. The synthesis is a summary of the corpus, not a summary of the author's prior knowledge.
+- If a synthesis claim cannot be cited to a card, it is a hint that a card is missing from the corpus. Either add the card (loop to Phase 1) or drop the claim.


### PR DESCRIPTION
Closes #23.

## Summary

- New skill `manuscript:lit-review`: multi-phase, citation-grounded literature review workflow modeled on the proven Annotation Garden Initiative protocol.
- New command `/manuscript:lit-review`: phase router with `--init`, `--phase`, `--strand` flags; auto-infers phase from directory state when no flag given.
- Six reference docs covering schemas, templates, license rules, and rigor gates.
- Plugin bump 0.2.0 -> 0.3.0; marketplace 0.5.3 -> 0.5.4.

## Workflow phases

| Phase | Output | Sister skill |
|---|---|---|
| 0. Angles | `_briefs/strand-*.md` | `project:epic-dev` |
| 1. Collection | `collection/<strand>/<slug>/{card.md, source.{pdf,md}, meta.json}` + INDEX + .bib | `opencite:opencite` |
| 2. Synthesis | `synthesis/{ontology, map, gap-analysis, scope-diagram}.md` | `opencite:literature-review` |
| 3. Direction | `direction-papers/<topic>-direction.md` (every claim cites a card) | `manuscript:manuscript-prep` + `manuscript-writing` |
| 4. Review | self-review pass; loop back as needed | `manuscript:paper-review` |

## Differentiation

- `opencite:literature-review`: single-pass thematic synthesis for a manuscript Introduction or standalone narrative review.
- `manuscript:lit-review` (this PR): multi-phase, iterable, corpus-grounded, traceable. For review papers, direction documents, and grant lit reviews where every claim must be defensible.

## Rigor gates

The skill enforces (via `references/rigor-checklist.md`):

- Traceability: every direction-paper claim links to a card path that actually supports the claim.
- Bias balance: gap analysis names what the corpus does NOT support; counterargument section is corpus-grounded.
- Reproducibility: a reader who clones the corpus can reconstruct the argument from `_briefs/`, `INDEX.md`, `synthesis/`, and `direction-papers/` alone.
- License-aware archival: `redistribution_ok: false` implies no `source.pdf` in repo; CI snippet provided.

## Test plan

- [ ] `manuscript:lit-review` skill loads on plugin reinstall (frontmatter parses, references resolve)
- [ ] `/manuscript:lit-review` command appears in slash command list
- [ ] `/manuscript:lit-review --init` bootstraps the directory layout in a clean dir
- [ ] `/manuscript:lit-review` (no args) correctly infers phase from current dir state
- [ ] Phase 1 dispatches to `opencite:opencite` for paper ops
- [ ] Phase 3 enforces cite-card cross-link convention
- [ ] No em-dashes, no emojis, no AI attribution in any new file
- [ ] JSON validity: `marketplace.json`, `plugin.json`