### PR TITLE
Add humanizer skill to manuscript plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, scientific figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -23,7 +23,7 @@
     {
       "name": "grant",
       "description": "Grant proposal toolkit: NIH/NSF writing with mechanism-specific templates, structured review with scoring criteria, and figure quality assurance",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"
@@ -34,8 +34,8 @@
     },
     {
       "name": "manuscript",
-      "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, and journal-specific formatting for submission",
-      "version": "0.4.2",
+      "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, journal-specific formatting for submission, and humanizer pass to remove AI-writing tells",
+      "version": "0.5.0",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "manuscript",
-      "description": "Academic manuscript toolkit: literature review, peer review, writing, and journal-specific formatting for submission",
+      "description": "Academic manuscript toolkit: literature review, peer review, writing, journal-specific formatting for submission, and humanizer pass to remove AI-writing tells",
       "version": "0.5.0",
       "source": "./plugins/manuscript",
       "category": "research"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Research and development plugins for literature search, grants, manuscripts, scientific figures, presentations, project lifecycle management, and neuroinformatics",
-    "version": "0.7.4"
+    "version": "0.7.6"
   },
   "plugins": [
     {
@@ -19,14 +19,14 @@
     {
       "name": "grant",
       "description": "Grant proposal toolkit: NIH/NSF writing with mechanism-specific templates, structured review with scoring criteria, and figure quality assurance",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "source": "./plugins/grant",
       "category": "research"
     },
     {
       "name": "manuscript",
       "description": "Academic manuscript toolkit: literature review, peer review, writing, and journal-specific formatting for submission",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "source": "./plugins/manuscript",
       "category": "research"
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ research-skills/
 │   ├── manuscript/                   # Academic manuscript toolkit
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── .codex-plugin/plugin.json
-│   │   └── skills/{paper-review,manuscript-writing,manuscript-formatting,lit-review}/
+│   │   └── skills/{paper-review,manuscript-writing,manuscript-formatting,lit-review,humanizer}/
 │   ├── opencite/                     # Literature search and citation management
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── .codex-plugin/plugin.json
@@ -53,8 +53,8 @@ research-skills/
 
 ## Plugins
 - **project** (v0.3.1): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing. Commands: `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep`.
-- **grant** (v0.3.1): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance. Skills only.
-- **manuscript** (v0.4.2): Literature review (multi-phase citation-traceable corpus protocol + single-pass thematic synthesis), peer review, writing guidance, and journal-specific formatting for submission. Skills only.
+- **grant** (v0.3.4): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance. Cross-references `manuscript:humanizer` from grant-writing and grant-review for natural-writing passes. Skills only.
+- **manuscript** (v0.5.0): Literature review (multi-phase citation-traceable corpus protocol + single-pass thematic synthesis), peer review, writing guidance, journal-specific formatting for submission, and the `humanizer` skill for a final natural-writing pass (adapted from [blader/humanizer](https://github.com/blader/humanizer), MIT, Siqi Chen). Skills only.
 - **opencite** (v0.3.1): Academic literature search, citation management, PDF retrieval, identifier conversion, and BibTeX export. Skills only. (Single-pass literature-review synthesis moved to `manuscript:lit-review`.)
 - **scientific-figures** (v0.2.1): Publication-quality figures covering icons, plots, composition, and QA. Icon generation auto-selects between Codex CLI (`codex login`) and OpenAI API (`OPENAI_API_KEY`).
 - **presentation** (v0.2.1): Interactive Reveal.js presentations from JSON via the Agentic Presentation Builder. Skills only.

--- a/plugins/grant/.claude-plugin/plugin.json
+++ b/plugins/grant/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grant",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Complete grant proposal toolkit: NIH/NSF proposal writing, structured review with scoring criteria, and figure quality assurance",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/grant/.codex-plugin/plugin.json
+++ b/plugins/grant/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grant",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Complete grant proposal toolkit: NIH/NSF proposal writing, structured review with scoring criteria, and figure quality assurance",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/grant/skills/grant-review/SKILL.md
+++ b/plugins/grant/skills/grant-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grant-review
 description: This skill should be used when the user asks to "review a grant", "review my proposal", "score this grant", "evaluate my specific aims", "critique my research strategy", "review as an NIH reviewer", "review as an NSF panelist", "give me reviewer feedback", "check my grant proposal", "review my R01", "review my K99", "evaluate my CAREER proposal", "run a mock study section", "review my resubmission", "review this PDF", "check my proposal PDF", "analyze my grant layout", or mentions grant review, proposal critique, NIH scoring, NSF panel review, study section feedback, or proposal PDF review.
-version: 0.1.1
+version: 0.1.2
 ---
 
 # Grant Proposal Review
@@ -142,6 +142,8 @@ Adopt the viewpoint of a **senior researcher** on a study section or review pane
 
 For common reviewer comments and their meanings, consult `references/review-best-practices.md`.
 
+When the proposal text triggers reviewer comments about "writing quality", "lack of specificity", "promotional language", or "buzzwords", point the applicant to `manuscript:humanizer`. Patterns most relevant to grant prose: 1 (significance inflation), 4 (promotional language), 7 (AI vocabulary), 8 (copula avoidance), 14 (em-dash overuse), 24 (excessive hedging), 25 (generic positive conclusions).
+
 ## Additional Resources
 
 ### Reference Files
@@ -150,6 +152,7 @@ For common reviewer comments and their meanings, consult `references/review-best
 - **`references/nsf-review-criteria.md`** - Complete NSF review criteria and panel process
 - **`references/review-best-practices.md`** - Best practices from experienced reviewers, common reviewer comments, and calibration guidance
 - **`references/review-output-templates.md`** - NIH and NSF review output format templates
+- **Sister skill `manuscript:humanizer`** - 29 AI-writing patterns to flag when assessing grant prose quality
 
 ### Examples
 - **`examples/sample-nih-r01-review.md`** - Complete example review demonstrating expected format, tone, and scoring calibration

--- a/plugins/grant/skills/grant-writing/SKILL.md
+++ b/plugins/grant/skills/grant-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grant-writing
 description: This skill should be used when the user asks to "write a grant proposal", "draft specific aims", "write a research strategy", "create an NIH proposal", "create an NSF proposal", "write a significance section", "write an innovation section", "write an approach section", "draft a DP2 essay", "write an R01", "write an R21", "write a K99", "write an R03", "write a K08", "write a K23", "write an F31", "write an F32", "write a CAREER proposal", "write preliminary data", "write rigor and reproducibility", "draft potential problems and alternatives", "write a budget justification", "respond to reviewer comments", "write a resubmission introduction", "strengthen my specific aims", "format grant text", or mentions grant writing, proposal drafting, specific aims, research strategy sections, or any NIH/NSF mechanism.
-version: 0.1.0
+version: 0.1.1
 ---
 
 # Grant Writing Skill
@@ -132,6 +132,13 @@ Consult `references/writing-style-guide.md` and `references/tone-guide.md` for e
 - Quantify when possible (N=24, 6-month, etc.)
 - Bold claims backed by technical precision
 - First person for vision ("I propose"), "we" for team work
+
+After drafting, run `manuscript:humanizer` as a final natural-writing pass. Pay particular attention to:
+
+- Pattern 1 (significance inflation): strip filler ("pivotal moment", "evolving landscape") but keep evidence-backed importance ("affects 1.2M patients annually").
+- Pattern 4 (promotional language): "groundbreaking", "transformative", "paradigm-shifting" read as red flags in Innovation sections. Let the methods carry the claim.
+- Pattern 24 (excessive hedging): tighten stacked hedges, but keep appropriate uncertainty in Approach risks/alternatives.
+- Patterns 17 and 19 (title case, curly quotes): for NIH/NSF, defer to mechanism formatting in Step 6.
 
 ### Step 6: Format for submission
 

--- a/plugins/manuscript/.claude-plugin/plugin.json
+++ b/plugins/manuscript/.claude-plugin/plugin.json
@@ -1,12 +1,28 @@
 {
   "name": "manuscript",
-  "version": "0.4.2",
-  "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, and journal-specific formatting for submission",
+  "version": "0.5.0",
+  "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, journal-specific formatting for submission, and humanizer pass to remove AI-writing tells",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"
   },
   "license": "BSD-3-Clause",
   "skills": "./skills/",
-  "keywords": ["manuscript", "paper", "peer-review", "writing", "formatting", "journal", "latex", "submission", "academic", "literature-review", "lit-review", "direction-paper"]
+  "keywords": [
+    "manuscript",
+    "paper",
+    "peer-review",
+    "writing",
+    "formatting",
+    "journal",
+    "latex",
+    "submission",
+    "academic",
+    "literature-review",
+    "lit-review",
+    "direction-paper",
+    "humanizer",
+    "ai-writing",
+    "ai-tells"
+  ]
 }

--- a/plugins/manuscript/.codex-plugin/plugin.json
+++ b/plugins/manuscript/.codex-plugin/plugin.json
@@ -1,12 +1,28 @@
 {
   "name": "manuscript",
-  "version": "0.4.2",
-  "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, and journal-specific formatting for submission",
+  "version": "0.5.0",
+  "description": "Academic manuscript toolkit: literature review (multi-phase citation-traceable + single-pass thematic), peer review, writing, journal-specific formatting for submission, and humanizer pass to remove AI-writing tells",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"
   },
   "license": "BSD-3-Clause",
   "skills": "./skills/",
-  "keywords": ["manuscript", "paper", "peer-review", "writing", "formatting", "journal", "latex", "submission", "academic", "literature-review", "lit-review", "direction-paper"]
+  "keywords": [
+    "manuscript",
+    "paper",
+    "peer-review",
+    "writing",
+    "formatting",
+    "journal",
+    "latex",
+    "submission",
+    "academic",
+    "literature-review",
+    "lit-review",
+    "direction-paper",
+    "humanizer",
+    "ai-writing",
+    "ai-tells"
+  ]
 }

--- a/plugins/manuscript/skills/humanizer/LICENSE
+++ b/plugins/manuscript/skills/humanizer/LICENSE
@@ -1,0 +1,34 @@
+The body of the SKILL.md in this directory is adapted from the upstream
+"humanizer" skill at https://github.com/blader/humanizer (v2.5.1), authored
+by Siqi Chen and licensed under the MIT License (reproduced below).
+
+The 29 AI-writing patterns, examples, and the "Personality and Soul" section
+are upstream content. The "Research writing context" section, the academic
+cross-references, and the frontmatter adapted for this marketplace are
+additions by the research-skills maintainers and are also released under MIT
+to preserve compatibility with upstream.
+
+------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2025 Siqi Chen
+Copyright (c) 2026 Seyed Yahya Shirazi (adaptations)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/manuscript/skills/humanizer/SKILL.md
+++ b/plugins/manuscript/skills/humanizer/SKILL.md
@@ -1,0 +1,623 @@
+---
+name: humanizer
+description: "Use this skill for \"humanize this text\", \"remove AI tells\", \"make this less AI-sounding\", \"strip AI patterns\", \"de-AI my writing\", \"reduce AI-isms\", \"final natural-writing pass\", \"check for AI vocabulary\", \"em dash overuse\", \"rule of three overuse\", \"AI vocabulary\", \"signs of AI writing\", or when polishing prose (papers, grants, lit reviews, abstracts, cover letters, responses to reviewers) to remove signs of AI-generated text while preserving meaning and discipline-appropriate conventions."
+version: 0.1.0
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+## Attribution
+
+The 29 patterns and the "Personality and Soul" section below are adapted from the upstream `humanizer` skill at https://github.com/blader/humanizer (v2.5.1) by Siqi Chen, released under the MIT License. The upstream patterns are themselves a distillation of [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.
+
+Additions for the research-skills marketplace: the "Research writing context" section, the "Reconciling with research-skills conventions" notes, and cross-references to sibling skills (`manuscript-writing`, `paper-review`, `manuscript-formatting`, `lit-review`, `grant-writing`, `grant-review`). The MIT license is preserved in the `LICENSE` file in this skill directory.
+
+## Your Task
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. When given text to humanize:
+
+1. **Identify AI patterns** by scanning for the patterns listed below.
+2. **Rewrite problematic sections** by replacing AI-isms with natural alternatives.
+3. **Preserve meaning** so the core message stays intact.
+4. **Maintain voice** to match the intended tone (formal, casual, technical, academic, grant-style).
+5. **Add soul** without just removing bad patterns; inject actual personality where the genre allows it.
+6. **Do a final anti-AI pass.** Prompt yourself: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise.
+
+## Research writing context
+
+Academic and grant writing have genre conventions that occasionally override generic "make it sound human" advice. Apply the patterns below with these calibrations:
+
+### When to soften or skip a pattern
+
+- **Passive voice in Methods.** Many biomedical, clinical, and life-sciences journals still prefer passive voice in Methods ("Samples were collected"). Active voice is preferred in research-skills overall, but do not force-rewrite Methods passages that match journal style. Pattern 13 still applies to Introduction, Results interpretation, Discussion, grant Approach narrative.
+- **Hedging in Limitations and Discussion.** Pattern 24 (excessive hedging) is real, but Discussion sections legitimately use "may", "suggests", "is consistent with". Trim *stacked* hedges ("could potentially possibly") to single hedges ("may"). Do not strip hedges to bare assertions you cannot defend.
+- **Significance language in grants.** Grant Significance sections legitimately argue that work matters. Pattern 1 (significance inflation) targets meaningless filler ("pivotal moment", "evolving landscape") — not specific, evidence-backed importance claims ("affects 1.2M patients annually"). Strip the filler, keep the substance.
+- **Title case in journal headings.** Pattern 17 prefers sentence case for headings. Defer to the journal's submission guidelines: IEEE, APA, ACS, and many others mandate title case. Apply pattern 17 only where house style is sentence case or unspecified.
+- **Curly quotes (pattern 19).** Many publishers' copyeditors convert straight quotes to curly automatically. For LaTeX submissions, use straight quotes (`` `` ... '' ``) since LaTeX renders them correctly. For Word/Markdown drafts, follow the journal's manuscript prep guide.
+- **Boldface in clinical and technical writing.** Pattern 15 targets *mechanical* bolding of every defined term. Selective bold for variable names, gene symbols (`*TP53*`), or critical warnings is fine.
+
+### Reconciling with research-skills conventions
+
+The `research-skills` marketplace project conventions already overlap with humanizer guidance. Treat humanizer as the *finishing pass* that enforces:
+
+- **No emojis** (pattern 18 + project rule). Strip on sight.
+- **No em-dashes** (pattern 14 + project rule). Replace with commas, periods, semicolons, or parentheses.
+- **Active voice** outside Methods (pattern 13 + project rule).
+- **Conciseness** (patterns 23, 24, 25 + project rule). "In order to" → "to", "due to the fact that" → "because".
+- **Define abbreviations before use** (project rule). Humanizer does not cover this; check during the same pass.
+
+If a journal's guide explicitly requires something humanizer flags (e.g., title case headings, formal third person), the journal wins. Note the exception in a brief revision note rather than fighting the style guide.
+
+### When to invoke this skill in the writing workflow
+
+- After drafting any section with `manuscript-writing` or `grant-writing`, before peer or self-review.
+- As the final polish step before `manuscript-formatting` (which applies journal-specific formatting on top).
+- During response-to-reviewers drafting, since reviewer letters benefit heavily from natural voice.
+- On synthesized lit-review prose from `lit-review` — these passages are particularly prone to "evolving landscape" filler.
+
+## Voice Calibration (Optional)
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. **Read the sample first.** Note:
+   - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
+   - Word choice level (casual? academic? somewhere between?)
+   - How they start paragraphs (jump right in? Set context first?)
+   - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
+   - Any recurring phrases or verbal tics
+   - How they handle transitions (explicit connectors? Just start the next point?)
+
+2. **Match their voice in the rewrite.** Do not just remove AI patterns; replace them with patterns from the sample. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
+
+3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below). For academic outputs without a sample, default to the conventions in `manuscript-writing` or `grant-writing`.
+
+### How to provide a sample
+
+- Inline: "Humanize this text. Here is a sample of my writing for voice matching: [sample]"
+- File: "Humanize this text. Use my writing style from [file path] as a reference."
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+In academic prose, "soul" is constrained but not absent. Choose specific examples over generic ones, name the gap your work addresses directly, and let opinions surface in Discussion sections (where they belong) rather than smothering them under "may suggest" stacks.
+
+### Signs of soulless writing (even if technically "clean")
+
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice
+
+**Have opinions.** Do not just report facts; react to them. "I genuinely do not know how to feel about this" is more human than neutrally listing pros and cons. In academic writing, the equivalent is a clear stance in Discussion: "We interpret this as X, though Y remains plausible."
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they are going. Mix it up.
+
+**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+
+**Use "I" or "we" when it fits.** First person is not unprofessional; it is honest. Most journals now accept "we measured" over "measurements were made". Defer to journal style.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human. In papers, this is harder; in cover letters and blog-style summaries, lean into it.
+
+**Be specific about feelings.** Not "this is concerning" but "there is something unsettling about agents churning away at 3am while nobody is watching."
+
+### Before (clean but soulless)
+
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse)
+
+> I genuinely do not know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it does not count. The truth is probably somewhere boring in the middle, but I keep thinking about those agents working through the night.
+
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+**Research writing note:** Grant Significance sections legitimately make importance claims; strip the filler ("pivotal moment", "evolving landscape") but keep substantive significance backed by evidence ("affects 1.2M patients annually", "no validated biomarker exists").
+
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics, and especially in grant Innovation sections.
+
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+**Research writing note:** Grant Innovation sections are particularly prone to this. "Groundbreaking", "transformative", "paradigm-shifting" land as red flags to reviewers. Let the methods speak.
+
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+**Research writing note:** Always cite. "Recent work has shown" without a citation is a peer-review red flag.
+
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+**Research writing note:** Discussion sections often need "Limitations" and "Future directions". That is fine; just write specifics ("our sample excluded subjects under 18") instead of generic templates ("Despite these limitations, this work opens exciting avenues").
+
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+
+### 9. Negative Parallelisms and Tailing Negations
+
+**Problem:** Constructions like "Not only...but..." or "It is not just about..., it is..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+
+**Before:**
+> It is not just about the beat riding under the vocals; it is part of the aggression and atmosphere. It is not merely a song, it is a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There is also time for informal networking between sessions.
+
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+**Research writing note:** In scientific writing, *repeat the same technical term* rather than cycling synonyms. Reviewers should not have to figure out whether "the cohort", "the sample", and "the participants" refer to the same group.
+
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y are not on a meaningful scale.
+
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+
+### 13. Passive Voice and Subjectless Fragments
+
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+**Research writing note:** Methods sections in many journals use passive intentionally ("Samples were collected and processed within 4 h"). Apply this pattern to Introduction, Results interpretation, Discussion, and grant Approach narrative. In Methods, only fix passives that genuinely obscure who did what.
+
+
+## STYLE PATTERNS
+
+### 14. Em Dash Overuse
+
+**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing. In practice, most of these can be rewritten more cleanly with commas, periods, or parentheses.
+
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You do not say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You do not say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+**Research writing note:** Research-skills project rule: no em-dashes anywhere. Use commas or semicolons.
+
+
+### 15. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+**Research writing note:** Selective bold for gene symbols, variable names, or NIH Specific Aims headers is fine. Mechanical bolding of every defined term is not.
+
+
+### 16. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+
+### 17. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+**Research writing note:** Many journals (IEEE, APA, ACS) require title case. Defer to the journal's submission guide. Apply this pattern only where house style is sentence case or unspecified.
+
+
+### 18. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+**Research writing note:** Research-skills project rule: no emojis in commits, PRs, code, or prose. Strip on sight.
+
+
+### 19. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+
+**Before:**
+> He said "the project is on track" but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+**Research writing note:** For LaTeX manuscripts use `` `` ... '' `` (LaTeX renders straight). For Word/Markdown, follow the publisher's manuscript prep guide.
+
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You are absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you would like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+
+### 21. Knowledge-Cutoff Disclaimers
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Problem:** AI disclaimers about incomplete information get left in text.
+
+**Before:**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+
+### 22. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+> Great question! You are absolutely right that this is a complex topic. That is an excellent point about the economic factors.
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+**Research writing note:** Response-to-reviewer letters are a frequent home for this. "We thank the reviewer for this excellent and insightful comment" can be tightened to "We thank the reviewer for this comment" or simply addressed directly.
+
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+
+### 24. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+**Research writing note:** Single hedges in Discussion are fine and often required. Strip stacked hedges ("could potentially possibly") to a single appropriate hedge ("may" or "suggests"). Do not strip to bare assertions you cannot defend with evidence.
+
+
+### 25. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+> The company plans to open two more locations next year.
+
+**Research writing note:** "This work opens exciting new avenues" is the classic Discussion-section AI tell. Replace with specific next steps: "Future work will test this in subjects with X."
+
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+
+**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it is inconsistent. Less common or technical compound modifiers are fine to hyphenate.
+
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
+
+**After:**
+> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
+
+**Research writing note:** Established compound modifiers used as adjectives before a noun ("high-throughput sequencing", "single-cell RNA-seq") stay hyphenated per scientific style. Strip only the generic management-speak hyphens.
+
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let us dive in, let us explore, let us break this down, here is what you need to know, now let us look at, without further ado
+
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+
+**Before:**
+> Let us dive into how caching works in Next.js. Here is what you need to know.
+
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+---
+
+## Process
+
+1. Read the input text carefully.
+2. If the text is academic prose, note which section it belongs to (Methods, Results, Discussion, grant Aims, grant Approach, response to reviewers, lit-review synthesis). Apply the "Research writing context" calibrations for that genre.
+3. Identify all instances of the patterns above.
+4. Rewrite each problematic section.
+5. Ensure the revised text:
+   - Sounds natural when read aloud
+   - Varies sentence structure naturally
+   - Uses specific details over vague claims
+   - Maintains appropriate tone for context (journal style, grant agency conventions)
+   - Uses simple constructions (is/are/has) where appropriate
+   - Defines abbreviations before use (project convention)
+6. Present a draft humanized version.
+7. Self-prompt: "What makes the below so obviously AI generated?"
+8. Answer briefly with remaining tells (if any).
+9. Self-prompt: "Now make it not obviously AI generated."
+10. Present the final version (revised after the audit).
+
+## Output Format
+
+Provide:
+
+1. Draft rewrite
+2. "What makes the below so obviously AI generated?" (brief bullets)
+3. Final rewrite
+4. A brief summary of changes made (optional, if helpful)
+
+## Cross-references in the research-skills marketplace
+
+- `manuscript:manuscript-writing` for paper drafting and section-level guidance. Run humanizer after drafting and before review.
+- `manuscript:paper-review` for peer-review feedback. Humanizer is often the right fix for a "writing quality" comment from a reviewer.
+- `manuscript:manuscript-formatting` for journal-specific formatting. Run humanizer first; formatting applies house style afterward (title case, citation style, etc.).
+- `manuscript:lit-review` for literature-review prose. The synthesized passages from lit-review are particularly prone to "evolving landscape" and "growing body of work" filler.
+- `grant:grant-writing` for NIH/NSF proposals. Run humanizer on Significance, Innovation, and Approach narrative. Pay extra attention to patterns 1 (significance inflation) and 4 (promotional language).
+- `grant:grant-review` for proposal critique. Patterns identified here often surface as "writing quality" or "lack of specificity" reviewer comments.
+
+## Full Example
+
+**Before (AI-sounding):**
+> Great question! Here is an essay on this topic. I hope this helps!
+>
+> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools, nestled at the intersection of research and practice, are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
+>
+> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It is not just about autocomplete; it is about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
+>
+> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
+>
+> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies, including hallucinations, bias, and accountability, the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
+>
+> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you would like me to expand on any section!
+
+**Draft rewrite:**
+> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+>
+> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
+>
+> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
+>
+> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
+>
+> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
+
+**What makes the below so obviously AI generated?**
+
+- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
+- The named people and study citations can read like plausible-but-made-up placeholders unless they are real and sourced.
+- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
+
+**Now make it not obviously AI generated.**
+> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
+>
+> They are great at boilerplate: config files, test scaffolding, repetitive refactors. They are also great at sounding right while being wrong. I have accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
+>
+> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they do not want. Both feel reasonable.
+>
+> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. If you do not have tests, you are basically guessing.
+
+**Changes made:**
+
+- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
+- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
+- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
+- Removed vague attributions ("Industry observers")
+- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
+- Removed negative parallelism ("It is not just X; it is Y")
+- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
+- Removed false ranges ("from X to Y, from A to B")
+- Removed em dashes, emojis, boldface headers, and curly quotes
+- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
+- Removed formulaic challenges section ("Despite challenges... continues to thrive")
+- Removed knowledge-cutoff hedging ("While specific details are limited...")
+- Removed excessive hedging ("could potentially be argued that... might have some")
+- Removed filler phrases and persuasive framing ("In order to", "At its core")
+- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
+- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
+
+
+## Reference
+
+This skill is adapted from [blader/humanizer](https://github.com/blader/humanizer) (MIT, Siqi Chen, 2025), which is itself based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) (WikiProject AI Cleanup).
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/plugins/manuscript/skills/humanizer/SKILL.md
+++ b/plugins/manuscript/skills/humanizer/SKILL.md
@@ -8,9 +8,18 @@ version: 0.1.0
 
 ## Attribution
 
-The 29 patterns and the "Personality and Soul" section below are adapted from the upstream `humanizer` skill at https://github.com/blader/humanizer (v2.5.1) by Siqi Chen, released under the MIT License. The upstream patterns are themselves a distillation of [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.
+This skill is adapted from the upstream `humanizer` skill at https://github.com/blader/humanizer (v2.5.1) by Siqi Chen, released under the MIT License. The upstream patterns are themselves a distillation of [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.
 
-Additions for the research-skills marketplace: the "Research writing context" section, the "Reconciling with research-skills conventions" notes, and cross-references to sibling skills (`manuscript-writing`, `paper-review`, `manuscript-formatting`, `lit-review`, `grant-writing`, `grant-review`). The MIT license is preserved in the `LICENSE` file in this skill directory.
+**Upstream content (preserved with minor copyedits):** the 29 AI-writing patterns and their before/after examples, the "Personality and Soul" section, the "Voice Calibration" section, the "Process" and "Output Format" sections, the "Full Example", and the closing "Reference" note.
+
+**Additions for the research-skills marketplace:**
+
+- The YAML frontmatter (rewritten in marketplace `description` style with academic-trigger phrases).
+- The "Research writing context" section (including the "When to soften or skip a pattern", "Reconciling with research-skills conventions", and "When to invoke this skill in the writing workflow" subsections).
+- The per-pattern "Research writing note" callouts on 11 of the 29 patterns.
+- The "Cross-references in the research-skills marketplace" section near the end.
+
+The MIT license is preserved in the `LICENSE` file in this skill directory; the additions above are released under MIT as well to keep upstream compatibility. National Institutes of Health (NIH), National Science Foundation (NSF), Institute of Electrical and Electronics Engineers (IEEE), American Psychological Association (APA), and American Chemical Society (ACS) referenced later in this file follow standard agency/society abbreviations.
 
 ## Your Task
 
@@ -31,7 +40,7 @@ Academic and grant writing have genre conventions that occasionally override gen
 
 - **Passive voice in Methods.** Many biomedical, clinical, and life-sciences journals still prefer passive voice in Methods ("Samples were collected"). Active voice is preferred in research-skills overall, but do not force-rewrite Methods passages that match journal style. Pattern 13 still applies to Introduction, Results interpretation, Discussion, grant Approach narrative.
 - **Hedging in Limitations and Discussion.** Pattern 24 (excessive hedging) is real, but Discussion sections legitimately use "may", "suggests", "is consistent with". Trim *stacked* hedges ("could potentially possibly") to single hedges ("may"). Do not strip hedges to bare assertions you cannot defend.
-- **Significance language in grants.** Grant Significance sections legitimately argue that work matters. Pattern 1 (significance inflation) targets meaningless filler ("pivotal moment", "evolving landscape") — not specific, evidence-backed importance claims ("affects 1.2M patients annually"). Strip the filler, keep the substance.
+- **Significance language in grants.** Grant Significance and Specific Aims sections legitimately argue that work matters. Pattern 1 (significance inflation) targets meaningless filler ("pivotal moment", "evolving landscape"), not specific, evidence-backed importance claims ("affects 1.2M patients annually"). Strip the filler, keep the substance.
 - **Title case in journal headings.** Pattern 17 prefers sentence case for headings. Defer to the journal's submission guidelines: IEEE, APA, ACS, and many others mandate title case. Apply pattern 17 only where house style is sentence case or unspecified.
 - **Curly quotes (pattern 19).** Many publishers' copyeditors convert straight quotes to curly automatically. For LaTeX submissions, use straight quotes (`` `` ... '' ``) since LaTeX renders them correctly. For Word/Markdown drafts, follow the journal's manuscript prep guide.
 - **Boldface in clinical and technical writing.** Pattern 15 targets *mechanical* bolding of every defined term. Selective bold for variable names, gene symbols (`*TP53*`), or critical warnings is fine.
@@ -53,7 +62,7 @@ If a journal's guide explicitly requires something humanizer flags (e.g., title 
 - After drafting any section with `manuscript-writing` or `grant-writing`, before peer or self-review.
 - As the final polish step before `manuscript-formatting` (which applies journal-specific formatting on top).
 - During response-to-reviewers drafting, since reviewer letters benefit heavily from natural voice.
-- On synthesized lit-review prose from `lit-review` — these passages are particularly prone to "evolving landscape" filler.
+- On synthesized lit-review prose from `lit-review`; these passages are particularly prone to "evolving landscape" filler.
 
 ## Voice Calibration (Optional)
 
@@ -120,7 +129,7 @@ In academic prose, "soul" is constrained but not absent. Choose specific example
 
 **Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
 
-**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+**Problem:** Large language model (LLM) writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
 
 **Before:**
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
@@ -521,7 +530,7 @@ In academic prose, "soul" is constrained but not absent. Choose specific example
 ## Process
 
 1. Read the input text carefully.
-2. If the text is academic prose, note which section it belongs to (Methods, Results, Discussion, grant Aims, grant Approach, response to reviewers, lit-review synthesis). Apply the "Research writing context" calibrations for that genre.
+2. If the text is academic prose, note which section it belongs to (Methods, Results, Discussion, grant Specific Aims, grant Significance, grant Approach, response to reviewers, lit-review synthesis). Apply the "Research writing context" calibrations for that genre.
 3. Identify all instances of the patterns above.
 4. Rewrite each problematic section.
 5. Ensure the revised text:
@@ -552,8 +561,8 @@ Provide:
 - `manuscript:paper-review` for peer-review feedback. Humanizer is often the right fix for a "writing quality" comment from a reviewer.
 - `manuscript:manuscript-formatting` for journal-specific formatting. Run humanizer first; formatting applies house style afterward (title case, citation style, etc.).
 - `manuscript:lit-review` for literature-review prose. The synthesized passages from lit-review are particularly prone to "evolving landscape" and "growing body of work" filler.
-- `grant:grant-writing` for NIH/NSF proposals. Run humanizer on Significance, Innovation, and Approach narrative. Pay extra attention to patterns 1 (significance inflation) and 4 (promotional language).
-- `grant:grant-review` for proposal critique. Patterns identified here often surface as "writing quality" or "lack of specificity" reviewer comments.
+- `grant:grant-writing` for NIH/NSF proposals. Run humanizer on Specific Aims, Significance, Innovation, and Approach narrative. Pay extra attention to patterns 1 (significance inflation), 4 (promotional language), and 24 (excessive hedging); defer to the funding mechanism's formatting for patterns 17 (title case) and 19 (curly quotes).
+- `grant:grant-review` for proposal critique. Patterns most relevant to grant prose: 1 (significance inflation), 4 (promotional language), 7 (AI vocabulary), 8 (copula avoidance), 14 (em-dash overuse), 24 (excessive hedging), 25 (generic positive conclusions). These often surface as "writing quality" or "lack of specificity" reviewer comments.
 
 ## Full Example
 

--- a/plugins/manuscript/skills/lit-review/SKILL.md
+++ b/plugins/manuscript/skills/lit-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lit-review
 description: "Use this skill for \"literature review workflow\", \"multi-phase lit review\", \"direction paper\", \"review paper protocol\", \"strand-based literature review\", \"citation-grounded review\", \"systematic lit review with paper cards\", \"build a lit review corpus\", \"lit review pipeline\", \"orchestrate a literature review\", \"research directions document\", \"write a literature review\", \"synthesize papers\", \"thematic review\", \"narrative review\", \"systematic review\", \"scoping review\", \"gap analysis\", or when the user wants either a rigorous multi-phase citation-traceable lit review or a single-pass thematic synthesis for an Introduction/Background section."
-version: 0.2.1
+version: 0.2.2
 ---
 
 # Multi-Phase Literature Review Workflow
@@ -171,6 +171,7 @@ The cite-card cross-link convention from Phase 3 still applies regardless of whe
 | `manuscript:manuscript-writing` | IMRAD / review-paper structure plus prose discipline (abbreviations, voice, transitions) |
 | `manuscript:manuscript-formatting` | Journal formatting / LaTeX export |
 | `manuscript:paper-review` | Self-review loops on direction-paper drafts |
+| `manuscript:humanizer` | Final natural-writing pass on synthesized prose. Lit-review synthesis sections are particularly prone to "evolving landscape", "growing body of work", and significance-inflation patterns; run humanizer before declaring a direction paper or Phase 2 synthesis complete. |
 | `project:epic-dev` | Formalize the lit-review phases (epic + sub-issues + worktrees + state file); also an upstream source of research angles when reviewing one's own project |
 
 ## References

--- a/plugins/manuscript/skills/manuscript-formatting/SKILL.md
+++ b/plugins/manuscript/skills/manuscript-formatting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manuscript-formatting
 description: "Use this skill for \"format manuscript\", \"prepare for submission\", \"journal formatting\", \"LaTeX template\", \"submission checklist\", \"format references\", \"BibTeX\", \"author guidelines\", \"page limits\", \"format for Nature\", \"format for IEEE\", or when the user wants to format a manuscript for journal submission."
-version: 0.2.0
+version: 0.2.1
 ---
 
 # Manuscript Formatting and Submission Preparation
@@ -123,7 +123,8 @@ Figure~\ref{fig:results}  % Standard format
 - [ ] Tables formatted per journal style
 - [ ] References complete and consistently formatted
 - [ ] Supplementary materials prepared separately
-- [ ] Cover letter drafted
+- [ ] Cover letter drafted (run `manuscript:humanizer` on it; cover letters are particularly prone to AI-tell phrasing)
+- [ ] `manuscript:humanizer` natural-writing pass applied to all narrative sections, *then* journal house style (title case, citation format, etc.) re-applied where it overrides humanizer defaults
 - [ ] Conflict of interest statement
 - [ ] Data availability statement
 - [ ] Ethics approval statement (if applicable)

--- a/plugins/manuscript/skills/manuscript-writing/SKILL.md
+++ b/plugins/manuscript/skills/manuscript-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manuscript-writing
 description: "Use this skill for \"write a paper\", \"draft manuscript\", \"write introduction\", \"write methods section\", \"write results\", \"write discussion\", \"write abstract\", \"structure a paper\", \"academic writing\", \"write for journal\", or when the user wants to draft or revise sections of an academic manuscript."
-version: 0.2.0
+version: 0.2.1
 ---
 
 # Academic Manuscript Writing
@@ -99,8 +99,10 @@ After drafting, check:
 - [ ] All abbreviations defined on first use
 - [ ] References complete and consistently formatted
 - [ ] Word/page count within journal limits
+- [ ] Run `manuscript:humanizer` as a final natural-writing pass (strips AI tells like significance inflation, em-dashes, "evolving landscape" filler, rule-of-three padding) before review
 
 ## Additional Resources
 
 - Reference: [references/section-templates.md](references/section-templates.md) - Templates for each manuscript section
 - Reference: [references/revision-response.md](references/revision-response.md) - How to write point-by-point responses to reviewers
+- Sister skill: `manuscript:humanizer` - Removes 29 categories of AI-writing tells while respecting academic conventions (e.g., passive voice in Methods, hedging in Discussion). Run after drafting and before peer review.

--- a/plugins/manuscript/skills/paper-review/SKILL.md
+++ b/plugins/manuscript/skills/paper-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-review
 description: "Use this skill for \"review this paper\", \"review this manuscript\", \"peer review\", \"review my paper\", \"critique this manuscript\", \"review this submission\", \"give me feedback on my paper\", \"check my methods\", \"review my statistics\", \"review as a peer reviewer\", \"evaluate this manuscript\", \"review this PDF\", or mentions manuscript review, peer review, paper critique, or methodological review."
-version: 0.1.0
+version: 0.1.1
 ---
 
 # Academic Manuscript Review
@@ -136,6 +136,7 @@ Read each figure and table carefully:
 - Are abbreviations defined on first use and not redefined?
 - Does the abstract accurately reflect the paper's content and findings?
 - Is the methods section complete per the target journal's guidelines?
+- Are there pervasive AI-writing tells (significance inflation, em-dashes, "evolving landscape" filler, rule-of-three padding, synonym cycling, generic positive conclusions)? When recommending writing fixes, point the author to `manuscript:humanizer` and cite specific patterns (e.g., "pattern 1, significance inflation; pattern 14, em-dash overuse").
 
 ## Review Output Format
 


### PR DESCRIPTION
Closes #29.

## Summary

Ingest the `humanizer` skill from https://github.com/blader/humanizer (MIT, Siqi Chen, 2025) as a peer skill inside the `manuscript` plugin, with cross-references from the writing-focused skills in both `manuscript` and `grant`.

## What landed

- New skill: `plugins/manuscript/skills/humanizer/{SKILL.md,LICENSE}`. The 29 AI-writing patterns and the Personality and Soul section are upstream verbatim; the file carries an Attribution section at the top, a Reference section at the bottom, and a dual-copyright MIT `LICENSE` in the skill directory.
- Light adaptation for research-skills context:
  - "Research writing context" section near the top, calibrating where academic genre conventions override generic advice (passive voice in Methods, hedging in Discussion/Limitations, significance language in grants, journal style guides for title case and curly quotes).
  - Explicit alignment with project rules already in CLAUDE.md (active voice, conciseness, no em-dashes, no emojis, define abbreviations on first use).
  - Per-pattern "Research writing note" callouts on 11 patterns where the rule has academic-specific calibration.
- Cross-references added from six sibling skills:
  - `manuscript:manuscript-writing` (revision checklist + Additional Resources)
  - `manuscript:paper-review` (assess-writing-quality bullet)
  - `manuscript:manuscript-formatting` (submission checklist)
  - `manuscript:lit-review` (sister-skills table)
  - `grant:grant-writing` (Step 5 writing-style guidance)
  - `grant:grant-review` (common reviewer-comments + Additional Resources)
- Version bumps per marketplace convention:
  - `manuscript` 0.4.2 -> 0.5.0 (minor: new skill)
  - `grant` 0.3.3 -> 0.3.4 (patch: cross-ref content edits)
  - marketplace 0.7.4 -> 0.7.6 (two cascading patches)
  - Six sibling skill frontmatter versions patch-bumped.
- `AGENTS.md` plugin list reflects the new versions and notes the humanizer attribution.

## Test plan

- [x] `jq empty` on all touched manifests passes
- [x] SKILL.md frontmatter parses cleanly as YAML
- [x] `./plugins/project/bin/project-bump-version --check` shows no drift across `.claude-plugin`, `.codex-plugin`, `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`
- [x] All version manifests aligned: manuscript=0.5.0 (claude/codex/cc-market/gh-market), grant=0.3.4 (claude/codex/cc-market/gh-market), marketplace=0.7.6 (claude + gh metadata)
- [ ] Reviewer to spot-check the SKILL.md attribution and the "Research writing context" reconciliations
- [ ] Reviewer to confirm cross-references read naturally inside their host skills

## Attribution

- Upstream: https://github.com/blader/humanizer v2.5.1, MIT License, Copyright (c) 2025 Siqi Chen
- Upstream-of-upstream: https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing (WikiProject AI Cleanup)
- Adaptations released under MIT (per LICENSE in the skill directory) to keep upstream compatibility