### PR TITLE
project: add init ADRs and default labels

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -11,7 +11,7 @@
     {
       "name": "project",
       "description": "Project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Research and development plugins for literature search, grants, manuscripts, figures, presentations, project lifecycle management, and neuroinformatics",
-    "version": "0.14.0"
+    "version": "0.14.1"
   },
   "plugins": [
     {
       "name": "project",
       "description": "Project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "source": "./plugins/project",
       "category": "development"
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ research-skills/
 ```
 
 ## Plugins
-- **project** (v0.3.3): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing. Commands: `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep`.
+- **project** (v0.4.0): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing. Commands: `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep`.
 - **grant** (v0.3.4): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance. Cross-references `manuscript:humanizer` from grant-writing and grant-review for natural-writing passes. Skills only.
 - **manuscript** (v0.5.0): Literature review (multi-phase citation-traceable corpus protocol + single-pass thematic synthesis), peer review, writing guidance, journal-specific formatting for submission, and the `humanizer` skill for a final natural-writing pass (adapted from [blader/humanizer](https://github.com/blader/humanizer), MIT, Siqi Chen). Skills only.
 - **opencite** (v0.3.1): Academic literature search, citation management, PDF retrieval, identifier conversion, and BibTeX export. Skills only. (Single-pass literature-review synthesis moved to `manuscript:lit-review`.)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Skills auto-trigger on user intent (described per-plugin below). Slash commands 
 
 | Plugin | Version | Description | Skills | Commands |
 |--------|---------|-------------|--------|----------|
-| **project** | 0.3.3 | Project lifecycle: init, rule/config updates, workflow, CI/CD, Docker, security, doc-processing | `init-project`, `update-rules`, `workflow-reference`, `ci-scaffolding`, `docker-packaging`, `security-audit`, `document-processing` | `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep` |
+| **project** | 0.4.0 | Project lifecycle: init, rule/config updates, workflow, CI/CD, Docker, security, doc-processing | `init-project`, `update-rules`, `workflow-reference`, `ci-scaffolding`, `docker-packaging`, `security-audit`, `document-processing` | `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep` |
 | **grant** | 0.3.4 | NIH/NSF grant proposal writing, review, and figure QA | `grant-writing`, `grant-review` | -- |
 | **manuscript** | 0.5.0 | Academic manuscript multi-phase + single-pass lit review, peer review, writing, journal formatting, and humanizer pass | `lit-review`, `paper-review`, `manuscript-writing`, `manuscript-formatting`, `humanizer` | -- |
 | **opencite** | 0.3.1 | Literature search, citation management, PDF retrieval | `opencite` | -- |
@@ -138,7 +138,7 @@ Neuroscience data standards, experiment design, and dataset validation:
 
 Complete project lifecycle toolkit combining initialization, epic/sprint workflow, and CI/CD management:
 
-- **init-project** -- scaffold new projects with AGENTS.md, a Claude Code CLAUDE.md import wrapper, `.rules/`, `.context/`, and config files
+- **init-project** -- scaffold new projects with AGENTS.md, a Claude Code CLAUDE.md import wrapper, `.rules/`, `.context/` including ADR decisions, optional default GitHub labels, and config files
 - **update-rules** -- non-destructive sync of AGENTS.md, the CLAUDE.md adapter, and `.rules/` against latest templates at user or project level
 - **workflow** -- multi-phase feature development with git worktrees, GitHub issues, and phased PR delivery
 - **CI scaffolding** -- generate GitHub Actions workflows for Python (ruff + pytest) or TypeScript (biome + bun test)

--- a/plugins/project/.claude-plugin/plugin.json
+++ b/plugins/project/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Complete project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/project/.codex-plugin/plugin.json
+++ b/plugins/project/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Complete project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/project/bin/project-init-labels
+++ b/plugins/project/bin/project-init-labels
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Install the default project label set for a GitHub repository.
+set -euo pipefail
+
+TARGET_DIR="${1:-.}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "ERROR: Target directory '$TARGET_DIR' does not exist or is not a directory" >&2
+    exit 1
+fi
+
+if ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: '$TARGET_DIR' is not a git repository" >&2
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI 'gh' is required to create labels" >&2
+    exit 1
+fi
+
+REPO="$(cd "$TARGET_DIR" && gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+if [ -z "$REPO" ]; then
+    echo "ERROR: '$TARGET_DIR' needs a GitHub origin remote visible to gh" >&2
+    exit 1
+fi
+
+create_label() {
+    local name="$1"
+    local color="$2"
+    local description="$3"
+
+    gh label create "$name" \
+        --repo "$REPO" \
+        --color "$color" \
+        --description "$description" \
+        --force
+}
+
+create_label "feature" "0E8A16" "New capability or user-visible improvement"
+create_label "bug" "D73A4A" "Incorrect behavior or regression"
+create_label "chore" "C5DEF5" "Maintenance, tooling, or non-user-facing work"
+create_label "docs" "0075CA" "Documentation changes"
+create_label "refactor" "BFDADC" "Internal restructuring without intended behavior change"
+
+create_label "P0" "B60205" "Critical priority; address immediately"
+create_label "P1" "D93F0B" "High priority"
+create_label "P2" "FBCA04" "Normal priority"
+create_label "P3" "C2E0C6" "Low priority or backlog"
+
+create_label "epic" "5319E7" "Parent issue for a larger body of work"
+create_label "good first issue" "7057FF" "Small, well-scoped contributor task"
+create_label "help wanted" "008672" "Maintainer-approved outside contribution welcome"
+create_label "blocked" "B60205" "Cannot proceed until a dependency is resolved"
+create_label "needs-triage" "D4C5F9" "Needs maintainer classification"
+
+echo "Installed default project labels"

--- a/plugins/project/bin/project-init-templates
+++ b/plugins/project/bin/project-init-templates
@@ -43,7 +43,7 @@ fi
 # .context/
 if [ ! -d "$TARGET_DIR/.context" ]; then
     mkdir -p "$TARGET_DIR/.context"
-    cp "$TEMPLATES_DIR/context/"*.md "$TARGET_DIR/.context/"
+    cp -R "$TEMPLATES_DIR/context/." "$TARGET_DIR/.context/"
     echo "Created .context/ directory"
 else
     echo ".context directory already exists, skipping"

--- a/plugins/project/commands/init-project.md
+++ b/plugins/project/commands/init-project.md
@@ -23,13 +23,21 @@ If the above command failed, report the exact error to the user and stop. Do not
 ### 3. Track agent files in git
 AGENTS.md, CLAUDE.md, .rules/, and .context/ are tracked in git by default. Add to .gitignore only if explicitly requested by the user.
 
-### 4. Customize AGENTS.md based on project context
+### 4. Optional default GitHub labels
+If the repository has already been initialized, pushed to GitHub, and the user asks for default labels, run:
+
+!project-init-labels .
+
+This command is idempotent and creates or updates the standard type, priority, and workflow labels.
+
+### 5. Customize AGENTS.md based on project context
 Now analyze the project and customize the AGENTS.md file using the project description provided by the user: `$ARGUMENTS`
 - Replace template placeholders: {{PROJECT_NAME}} with the project name, {{framework}} with the detected framework
 - Use `$ARGUMENTS` as the project purpose in the "Project Context" section
 - Add project-specific instructions based on detected language/framework
 - Update .rules/ contents to match project needs; remove irrelevant rules
 - Update .context/ files with project requirements; keep minimal instructions for unused files
+- Put durable architecture decisions in `.context/decisions/` using the ADR template and `NNNN-short-title.md` naming convention
 - Keep CLAUDE.md as `@AGENTS.md` followed only by Claude Code-specific plugin, skill, command, or MCP instructions
 - Re-read AGENTS.md and CLAUDE.md to ensure only relevant context and rules are referenced
 
@@ -38,14 +46,14 @@ Now analyze the project and customize the AGENTS.md file using the project descr
 !if [ -f "Cargo.toml" ]; then echo "Detected: Rust project"; fi
 !if [ -f "go.mod" ]; then echo "Detected: Go project"; fi
 
-### 5. Cursor setup (optional)
+### 6. Cursor setup (optional)
 If the user also uses Cursor, offer to set up Cursor templates.
 Use `project-templates-path` to locate the templates directory, then copy:
 - .cursorrules from `<templates>/cursor/`
 - core_rules/ .mdc files
 - Planning workflow (default or advanced-taskmaster based on preference)
 
-### 6. Verify initialization
+### 7. Verify initialization
 !echo "\n=== Initialization Verification ===" && \
   for f in AGENTS.md CLAUDE.md .rules .context; do \
     if [ -e "$f" ]; then echo "[OK] $f exists"; else echo "[MISSING] $f was NOT created"; fi; \

--- a/plugins/project/skills/init-project/SKILL.md
+++ b/plugins/project/skills/init-project/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: init-project
 description: "Use this skill for \"initialize project\", \"set up project\", \"scaffold project\", \"create AGENTS.md\", \"create CLAUDE.md\", \"set up rules\", \"create context directory\", \"vibe rules\", \"project templates\", \"init new project\", \"set up development structure\", \"create .rules\", \"create .context\", \"project scaffolding\", \"set up pre-commit hooks\", or when the user wants to initialize a new project with cross-agent development templates and structured documentation."
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Project Initialization with Vibe Rules Templates
@@ -39,6 +39,9 @@ templates/
     ideas.md          # Design concepts
     research.md       # Technical explorations
     scratch_history.md # Failed attempts and lessons
+    decisions/         # Architecture Decision Records (ADRs)
+      0000-template.md # ADR template
+      README.md        # ADR naming and workflow convention
   config/           # Development configuration
     pre-commit        # Ruff pre-commit hook (Python)
     pyproject.toml    # Python project config
@@ -75,6 +78,7 @@ Copy with safety checks (never overwrite existing files):
 2. **CLAUDE.md** from `templates/claude/CLAUDE.md` (contains `@AGENTS.md`, then Claude-only guidance)
 3. **.rules/** from `templates/claude/rules/` (all .md files)
 4. **.context/** from `templates/context/` (plan, ideas, research, scratch_history)
+   including `.context/decisions/` for Architecture Decision Records (ADRs)
 
 ### Step 3: Language-specific setup
 
@@ -84,6 +88,7 @@ Copy with safety checks (never overwrite existing files):
 
 **All projects:**
 - Offer GitHub Actions workflows from `templates/github/workflows/` if `.github/workflows/` does not exist
+- If the repository has already been pushed to GitHub and the user asks for default labels, run `project-init-labels .` to create or update the standard type, priority, and workflow labels.
 
 ### Step 4: Customize AGENTS.md and keep CLAUDE.md as an adapter
 
@@ -129,3 +134,5 @@ Read `references/rules-guide.md` for detailed descriptions of each rule file and
 ## Context Directory Reference
 
 Read `references/context-guide.md` for how to use each .context/ file effectively.
+
+Architecture decisions belong in `.context/decisions/` using the `NNNN-short-title.md` naming convention and the bundled `0000-template.md`.

--- a/plugins/project/skills/init-project/references/context-guide.md
+++ b/plugins/project/skills/init-project/references/context-guide.md
@@ -55,6 +55,17 @@ The `.context/` directory provides structured documentation that persists across
 
 **When to update:** Immediately after a failed attempt. Capture the details while they are fresh. This file prevents repeating the same mistakes.
 
+### decisions/
+
+**Purpose:** Store Architecture Decision Records (ADRs) for durable choices that affect structure, dependencies, interfaces, deployment, data models, or operating rules.
+
+**Structure:**
+- `README.md` documents the naming convention
+- `0000-template.md` is copied for each new decision
+- New decisions use `NNNN-short-title.md` with Context, Decision, Consequences, Alternatives, and Receipts sections
+
+**When to update:** When a decision would be expensive or confusing to rediscover later. Link issues, PRs, benchmarks, incidents, or tests under Receipts.
+
 ## Usage Guidelines
 
 1. Keep entries concise but complete enough to be useful months later
@@ -62,3 +73,4 @@ The `.context/` directory provides structured documentation that persists across
 3. Cross-reference between files (e.g., a failed attempt in scratch_history might link to the research that led to a better solution)
 4. These files are tracked in git by default, providing a shared knowledge base for the team
 5. For unused context files, keep the template structure with minimal instructions on how to start using them
+6. Keep ADRs short and immutable after merge; supersede old decisions with a new record rather than rewriting history

--- a/plugins/project/templates/context/decisions/0000-template.md
+++ b/plugins/project/templates/context/decisions/0000-template.md
@@ -1,0 +1,28 @@
+# 0000: Decision Title
+
+- Date: YYYY-MM-DD
+- Status: proposed
+- Owners: project maintainers
+
+## Context
+
+Describe the situation, constraints, and forces that make this decision
+necessary. Include relevant requirements, failure modes, and prior decisions.
+
+## Decision
+
+State the chosen approach directly. Include the boundary of the decision so
+future changes know what is and is not covered.
+
+## Consequences
+
+List the expected tradeoffs, follow-up work, migration costs, and operational
+impact. Include both benefits and liabilities.
+
+## Alternatives
+
+Summarize serious alternatives considered and why they were not selected.
+
+## Receipts
+
+- Link to related issues, PRs, docs, benchmark output, incidents, or tests.

--- a/plugins/project/templates/context/decisions/README.md
+++ b/plugins/project/templates/context/decisions/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Use this directory for Architecture Decision Records (ADRs): short, dated notes
+that explain important project choices and their consequences.
+
+## Naming
+
+Name each record with a numeric prefix and short title:
+
+```text
+0001-use-postgres-for-events.md
+0002-keep-worker-state-in-redis.md
+```
+
+Keep numbers monotonic. Do not renumber existing records after they are merged.
+
+## Workflow
+
+1. Copy `0000-template.md`.
+2. Rename it to the next `NNNN-short-title.md`.
+3. Fill in Context, Decision, Consequences, Alternatives, and Receipts.
+4. Link relevant issues, PRs, docs, or test output under Receipts.
+
+ADRs should be concise enough to read quickly but concrete enough that a future
+agent or maintainer can understand why the decision exists.


### PR DESCRIPTION
## Summary
- add `.context/decisions/` ADR templates and copy nested context templates during project init
- add `project-init-labels` for idempotent default GitHub type/priority/workflow labels
- document the optional label step and bump project/marketplace versions

Closes #53.

## Verification
- `bash -n plugins/project/bin/project-templates-path plugins/project/bin/project-init-templates plugins/project/bin/project-init-labels`
- `project-init-templates` copies `.context/decisions/0000-template.md` and `README.md` into a fresh target
- JSON manifests parse
- `git diff --check`