### PR TITLE
init-project: scaffold .context/decisions/ for ADRs and optional GitHub labels (#53)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "project",
-      "description": "Project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
-      "version": "0.3.3",
+      "description": "Project lifecycle toolkit: initialization (with ADR scaffold and optional GitHub label set), rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
+      "version": "0.4.0",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,8 @@ HED = "HED"
 rcParams = "rcParams"
 PNGs = "PNGs"
 PN = "PN"
+# numpy function (typos thinks it should be "arrange")
+arange = "arange"
 # BIDS coordinate system
 CapTrak = "CapTrak"
 Trak = "Trak"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ research-skills/
 ```
 
 ## Plugins
-- **project** (v0.3.3): Project lifecycle toolkit with initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing. Commands: `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep`.
+- **project** (v0.4.0): Project lifecycle toolkit with initialization (now scaffolds `.context/decisions/` for Architecture Decision Records and offers an optional default GitHub label set via `project-init-labels`), rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security audit, and document processing. Commands: `/init-project`, `/update-rules`, `/epic-dev`, `/epic-status`, `/release-prep`.
 - **grant** (v0.3.4): NIH/NSF grant proposal writing, structured review with scoring criteria, and figure quality assurance. Cross-references `manuscript:humanizer` from grant-writing and grant-review for natural-writing passes. Skills only.
 - **manuscript** (v0.5.0): Literature review (multi-phase citation-traceable corpus protocol + single-pass thematic synthesis), peer review, writing guidance, journal-specific formatting for submission, and the `humanizer` skill for a final natural-writing pass (adapted from [blader/humanizer](https://github.com/blader/humanizer), MIT, Siqi Chen). Skills only.
 - **opencite** (v0.3.1): Academic literature search, citation management, PDF retrieval, identifier conversion, and BibTeX export. Skills only. (Single-pass literature-review synthesis moved to `manuscript:lit-review`.)

--- a/plugins/project/.claude-plugin/plugin.json
+++ b/plugins/project/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project",
-  "version": "0.3.3",
-  "description": "Complete project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
+  "version": "0.4.0",
+  "description": "Complete project lifecycle toolkit: initialization (with ADR scaffold and optional GitHub label set), rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"

--- a/plugins/project/.codex-plugin/plugin.json
+++ b/plugins/project/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project",
-  "version": "0.3.3",
-  "description": "Complete project lifecycle toolkit: initialization, rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
+  "version": "0.4.0",
+  "description": "Complete project lifecycle toolkit: initialization (with ADR scaffold and optional GitHub label set), rule/config updates, epic/sprint workflow, CI/CD scaffolding, Docker packaging, security auditing, and document processing",
   "author": {
     "name": "Seyed Yahya Shirazi",
     "email": "shirazi@ieee.org"

--- a/plugins/project/bin/project-init-labels
+++ b/plugins/project/bin/project-init-labels
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Install a default GitHub label set on the current repository.
+# Idempotent: existing labels are updated in place via `gh label create --force`.
+# Requires: gh CLI authenticated and the working directory inside a GitHub-hosted repo.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not found. Install GitHub CLI before running this script." >&2
+    exit 1
+fi
+
+TARGET_DIR="${1:-.}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "ERROR: Target directory '$TARGET_DIR' does not exist or is not a directory" >&2
+    exit 1
+fi
+
+if ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: '$TARGET_DIR' is not a git repository." >&2
+    exit 1
+fi
+
+if ! (cd "$TARGET_DIR" && gh repo view >/dev/null 2>&1); then
+    echo "ERROR: no GitHub remote detected for '$TARGET_DIR'. Push the repo to GitHub first, then re-run." >&2
+    exit 1
+fi
+
+# Label set: name | color (hex, no #) | description.
+# Colors follow GitHub's defaults where applicable so labels look familiar across repos.
+LABELS=(
+    "feature|a2eeef|New feature or enhancement"
+    "bug|d73a4a|Something isn't working"
+    "chore|cfd3d7|Maintenance, dependencies, tooling"
+    "docs|0075ca|Documentation changes"
+    "refactor|fbca04|Internal restructuring without behavior change"
+    "P0|b60205|Critical: drop everything"
+    "P1|d93f0b|High priority"
+    "P2|fbca04|Medium priority"
+    "P3|0e8a16|Low priority"
+    "epic|6B3FA0|Multi-phase feature epic"
+    "blocked|e99695|Blocked on another task or external dependency"
+    "needs-triage|ededed|Awaiting initial review"
+    "good first issue|7057ff|Good for newcomers"
+    "help wanted|008672|Extra attention is needed"
+)
+
+ensured=0
+failed=0
+
+cd "$TARGET_DIR"
+
+for entry in "${LABELS[@]}"; do
+    IFS='|' read -r name color description <<<"$entry"
+    if gh label create "$name" --color "$color" --description "$description" --force >/dev/null 2>&1; then
+        ensured=$((ensured + 1))
+        echo "  [ok] $name"
+    else
+        failed=$((failed + 1))
+        echo "  [failed] $name" >&2
+    fi
+done
+
+echo "Labels: ${ensured} ensured, ${failed} failed."
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi

--- a/plugins/project/bin/project-init-labels
+++ b/plugins/project/bin/project-init-labels
@@ -21,10 +21,12 @@ if ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! (cd "$TARGET_DIR" && gh repo view >/dev/null 2>&1); then
-    echo "ERROR: no GitHub remote detected for '$TARGET_DIR'. Push the repo to GitHub first, then re-run." >&2
+repo_check_err="$(cd "$TARGET_DIR" && gh repo view 2>&1 >/dev/null)" || {
+    echo "ERROR: gh could not resolve a GitHub repo for '$TARGET_DIR'." >&2
+    echo "  gh output: $repo_check_err" >&2
+    echo "  Common causes: repo not yet pushed to GitHub, expired auth (run 'gh auth status'), or no read access." >&2
     exit 1
-fi
+}
 
 # Label set: name | color (hex, no #) | description.
 # Colors follow GitHub's defaults where applicable so labels look familiar across repos.
@@ -52,12 +54,12 @@ cd "$TARGET_DIR"
 
 for entry in "${LABELS[@]}"; do
     IFS='|' read -r name color description <<<"$entry"
-    if gh label create "$name" --color "$color" --description "$description" --force >/dev/null 2>&1; then
+    if err="$(gh label create "$name" --color "$color" --description "$description" --force 2>&1 >/dev/null)"; then
         ensured=$((ensured + 1))
         echo "  [ok] $name"
     else
         failed=$((failed + 1))
-        echo "  [failed] $name" >&2
+        echo "  [failed] $name: $err" >&2
     fi
 done
 

--- a/plugins/project/bin/project-init-templates
+++ b/plugins/project/bin/project-init-templates
@@ -31,10 +31,30 @@ else
     echo "CLAUDE.md already exists, skipping"
 fi
 
+# Copy every *.md from a source dir into a target dir, failing loudly under
+# `set -euo pipefail` if the source dir is missing or contains no .md files
+# (broken install, partial checkout) instead of letting an unmatched glob
+# produce a cryptic cp error.
+copy_md_files() {
+    local src="$1" dest="$2" label="$3"
+    if [ ! -d "$src" ]; then
+        echo "ERROR: template directory missing: $src" >&2
+        exit 1
+    fi
+    shopt -s nullglob
+    local files=("$src"/*.md)
+    shopt -u nullglob
+    if [ ${#files[@]} -eq 0 ]; then
+        echo "ERROR: no .md files found in $src (broken $label template install)" >&2
+        exit 1
+    fi
+    cp "${files[@]}" "$dest/"
+}
+
 # .rules/
 if [ ! -d "$TARGET_DIR/.rules" ]; then
     mkdir -p "$TARGET_DIR/.rules"
-    cp "$TEMPLATES_DIR/claude/rules/"*.md "$TARGET_DIR/.rules/"
+    copy_md_files "$TEMPLATES_DIR/claude/rules" "$TARGET_DIR/.rules" ".rules"
     echo "Created .rules/ directory"
 else
     echo ".rules directory already exists, skipping"
@@ -43,7 +63,7 @@ fi
 # .context/
 if [ ! -d "$TARGET_DIR/.context" ]; then
     mkdir -p "$TARGET_DIR/.context"
-    cp "$TEMPLATES_DIR/context/"*.md "$TARGET_DIR/.context/"
+    copy_md_files "$TEMPLATES_DIR/context" "$TARGET_DIR/.context" ".context"
     echo "Created .context/ directory"
 else
     echo ".context directory already exists, skipping top-level files"
@@ -53,7 +73,7 @@ fi
 # Created independently of .context/ so existing projects pick it up on re-run.
 if [ ! -d "$TARGET_DIR/.context/decisions" ]; then
     mkdir -p "$TARGET_DIR/.context/decisions"
-    cp "$TEMPLATES_DIR/context/decisions/"*.md "$TARGET_DIR/.context/decisions/"
+    copy_md_files "$TEMPLATES_DIR/context/decisions" "$TARGET_DIR/.context/decisions" ".context/decisions"
     echo "Created .context/decisions/ directory"
 else
     echo ".context/decisions directory already exists, skipping"

--- a/plugins/project/bin/project-init-templates
+++ b/plugins/project/bin/project-init-templates
@@ -46,7 +46,17 @@ if [ ! -d "$TARGET_DIR/.context" ]; then
     cp "$TEMPLATES_DIR/context/"*.md "$TARGET_DIR/.context/"
     echo "Created .context/ directory"
 else
-    echo ".context directory already exists, skipping"
+    echo ".context directory already exists, skipping top-level files"
+fi
+
+# .context/decisions/ for Architecture Decision Records.
+# Created independently of .context/ so existing projects pick it up on re-run.
+if [ ! -d "$TARGET_DIR/.context/decisions" ]; then
+    mkdir -p "$TARGET_DIR/.context/decisions"
+    cp "$TEMPLATES_DIR/context/decisions/"*.md "$TARGET_DIR/.context/decisions/"
+    echo "Created .context/decisions/ directory"
+else
+    echo ".context/decisions directory already exists, skipping"
 fi
 
 # Python pre-commit hook

--- a/plugins/project/commands/init-project.md
+++ b/plugins/project/commands/init-project.md
@@ -21,7 +21,7 @@ Initialize this project using bundled vibe-rules templates from the init-project
 If the above command failed, report the exact error to the user and stop. Do not proceed with remaining steps.
 
 ### 3. Track agent files in git
-AGENTS.md, CLAUDE.md, .rules/, and .context/ are tracked in git by default. Add to .gitignore only if explicitly requested by the user.
+AGENTS.md, CLAUDE.md, .rules/, and .context/ (including `.context/decisions/`) are tracked in git by default. Add to .gitignore only if explicitly requested by the user. The `.context/decisions/` directory holds Architecture Decision Records; copy `0000-template.md` to start a new ADR.
 
 ### 4. Customize AGENTS.md based on project context
 Now analyze the project and customize the AGENTS.md file using the project description provided by the user: `$ARGUMENTS`
@@ -45,15 +45,27 @@ Use `project-templates-path` to locate the templates directory, then copy:
 - core_rules/ .mdc files
 - Planning workflow (default or advanced-taskmaster based on preference)
 
-### 6. Verify initialization
+### 6. GitHub labels (optional, post-push)
+Only after the repo has been pushed to GitHub, ask the user whether they want the default issue/PR label set installed. If yes:
+
+!project-init-labels .
+
+The script is idempotent and installs:
+- Type: `feature`, `bug`, `chore`, `docs`, `refactor`
+- Priority: `P0`, `P1`, `P2`, `P3`
+- Workflow: `epic`, `blocked`, `needs-triage`, `good first issue`, `help wanted`
+
+Skip this step if the project is not yet on GitHub, or if the user prefers to manage labels by hand. Do not run it without asking.
+
+### 7. Verify initialization
 !echo "\n=== Initialization Verification ===" && \
-  for f in AGENTS.md CLAUDE.md .rules .context; do \
+  for f in AGENTS.md CLAUDE.md .rules .context .context/decisions; do \
     if [ -e "$f" ]; then echo "[OK] $f exists"; else echo "[MISSING] $f was NOT created"; fi; \
   done
 
 Now help customize the AGENTS.md file to document:
 - Project-specific goals and instructions
-- What's in the .context directory (plan, ideas, research, scratch_history)
+- What's in the .context directory (plan, ideas, research, scratch_history, decisions/)
 - What rules are in .rules/ and which are relevant
 - References to any existing planning documents
 

--- a/plugins/project/skills/init-project/SKILL.md
+++ b/plugins/project/skills/init-project/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: init-project
-description: "Use this skill for \"initialize project\", \"set up project\", \"scaffold project\", \"create AGENTS.md\", \"create CLAUDE.md\", \"set up rules\", \"create context directory\", \"vibe rules\", \"project templates\", \"init new project\", \"set up development structure\", \"create .rules\", \"create .context\", \"project scaffolding\", \"set up pre-commit hooks\", or when the user wants to initialize a new project with cross-agent development templates and structured documentation."
-version: 0.1.0
+description: "Use this skill for \"initialize project\", \"set up project\", \"scaffold project\", \"create AGENTS.md\", \"create CLAUDE.md\", \"set up rules\", \"create context directory\", \"vibe rules\", \"project templates\", \"init new project\", \"set up development structure\", \"create .rules\", \"create .context\", \"create ADR\", \"architecture decision records\", \"set up GitHub labels\", \"default issue labels\", \"project scaffolding\", \"set up pre-commit hooks\", or when the user wants to initialize a new project with cross-agent development templates, structured documentation, and an optional default GitHub label set."
+version: 0.2.0
 ---
 
 # Project Initialization with Vibe Rules Templates
@@ -39,6 +39,9 @@ templates/
     ideas.md          # Design concepts
     research.md       # Technical explorations
     scratch_history.md # Failed attempts and lessons
+    decisions/        # Architecture Decision Records
+      README.md         # ADR convention (numbering, statuses, when to write one)
+      0000-template.md  # Template for new ADRs (do not edit)
   config/           # Development configuration
     pre-commit        # Ruff pre-commit hook (Python)
     pyproject.toml    # Python project config
@@ -75,6 +78,7 @@ Copy with safety checks (never overwrite existing files):
 2. **CLAUDE.md** from `templates/claude/CLAUDE.md` (contains `@AGENTS.md`, then Claude-only guidance)
 3. **.rules/** from `templates/claude/rules/` (all .md files)
 4. **.context/** from `templates/context/` (plan, ideas, research, scratch_history)
+5. **.context/decisions/** from `templates/context/decisions/` (ADR template and README). Created separately so existing projects that already have `.context/` still pick it up on re-run.
 
 ### Step 3: Language-specific setup
 
@@ -107,7 +111,22 @@ Only if the user requests it or uses Cursor:
 - Copy `core_rules/` .mdc files
 - Offer planning workflow choice: default (plan-based) or advanced-taskmaster
 
-### Step 6: Verify and summarize
+### Step 6: GitHub labels (optional, post-push)
+
+If (and only if) the project has been pushed to GitHub and the user opts in, install a default issue label set:
+
+```bash
+project-init-labels .
+```
+
+The script is idempotent (uses `gh label create --force`) and installs:
+- **Type:** `feature`, `bug`, `chore`, `docs`, `refactor`
+- **Priority:** `P0` (critical), `P1` (high), `P2` (medium), `P3` (low)
+- **Workflow:** `epic`, `blocked`, `needs-triage`, `good first issue`, `help wanted`
+
+Skip this step entirely if the project is not on GitHub yet, or if the user prefers to manage labels by hand. Do not run it without asking.
+
+### Step 7: Verify and summarize
 
 List created files and directories. Confirm the structure is correct before the user starts working.
 

--- a/plugins/project/skills/init-project/references/context-guide.md
+++ b/plugins/project/skills/init-project/references/context-guide.md
@@ -55,6 +55,21 @@ The `.context/` directory provides structured documentation that persists across
 
 **When to update:** Immediately after a failed attempt. Capture the details while they are fresh. This file prevents repeating the same mistakes.
 
+### decisions/
+
+**Purpose:** Architecture Decision Records (ADRs). One file per significant decision, tucked together so they are easy to find later.
+
+**Structure:**
+- `README.md` documents the convention (numbering, statuses, when to write one).
+- `0000-template.md` is the template; copy it to start a new ADR. Do not edit it directly.
+- Decisions are numbered `NNNN-short-kebab-title.md` (zero-padded to four digits, sequential).
+- Each ADR has: Status, Date, Owner, Context, Decision, Consequences, Alternatives considered, Receipts.
+- Status flows `proposed` -> `accepted` -> (later) `superseded by ADR-NNNN`. Never delete an ADR; supersede it.
+
+**When to write one:** When the decision will be hard or expensive to reverse, cuts off other reasonable paths, has been argued about more than once, or embeds a non-obvious constraint (legal, performance, schedule). Skip ADRs for routine choices already obvious from the code.
+
+**Relation to ideas.md and research.md:** `ideas.md` and `research.md` are exploratory and frequently rewritten. ADRs are the durable record of what was actually chosen and why. Promote an idea or research conclusion to an ADR once the decision is final.
+
 ## Usage Guidelines
 
 1. Keep entries concise but complete enough to be useful months later

--- a/plugins/project/templates/context/decisions/0000-template.md
+++ b/plugins/project/templates/context/decisions/0000-template.md
@@ -1,0 +1,26 @@
+# ADR NNNN: Short decision title
+
+**Status:** proposed | accepted | superseded by ADR-NNNN
+**Date:** YYYY-MM-DD
+**Owner:** <name>
+
+## Context
+
+What is the situation that forces a decision? Two to four sentences. Include the constraints that matter (technical, legal, scheduling, organizational).
+
+## Decision
+
+The decision in one or two sentences. Active voice.
+
+## Consequences
+
+What becomes easier, what becomes harder, what new obligations are created. Be honest about the downsides.
+
+## Alternatives considered
+
+- **Alternative A:** what it was, why it lost.
+- **Alternative B:** what it was, why it lost.
+
+## Receipts
+
+Links, prior art, or commit references that informed the decision.

--- a/plugins/project/templates/context/decisions/README.md
+++ b/plugins/project/templates/context/decisions/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) capture significant decisions that shape the project: choice of stack, structural patterns, trade-offs accepted, alternatives rejected. Tuck them all in here so they are easy to find later.
+
+## Convention
+
+- One file per decision: `NNNN-short-kebab-title.md`, zero-padded to four digits.
+- `0000-template.md` is the template; copy it to start a new ADR. Do not edit `0000-template.md` itself.
+- Number sequentially. The next ADR after `0007-...` is `0008-...`.
+- Status flows `proposed` -> `accepted` -> (later) `superseded by ADR-NNNN`. Never delete an ADR; supersede it.
+- Keep each ADR short. If it grows past two screens, you are probably writing a design doc, not a decision.
+
+## When to write an ADR
+
+Write one when a decision:
+- Will be hard or expensive to reverse.
+- Cuts off other reasonable paths a future contributor might wonder about.
+- Has been argued about more than once.
+- Embeds a constraint (legal, performance, schedule) that is not obvious from the code.
+
+Do not write one for routine choices that are obvious from reading the code.
+
+## Index
+
+Add new entries here as you create ADRs:
+
+- ADR 0000 - template (do not edit)


### PR DESCRIPTION
Closes #53.

## Summary
- Adds `.context/decisions/` to the project init scaffold: `0000-template.md` (ADR template, do not edit) plus a `README.md` documenting the numbering, status flow, and when to write an ADR. Modeled after the convention in `neurality-dev/companion/.context/decisions/`.
- Adds `bin/project-init-labels`, an idempotent `gh`-based installer for a default issue/PR label set:
  - Type: `feature`, `bug`, `chore`, `docs`, `refactor`
  - Priority: `P0` (critical) -> `P3` (low)
  - Workflow: `epic`, `blocked`, `needs-triage`, `good first issue`, `help wanted`
- Wires both into the `init-project` skill and the `/init-project` command. Labels step is opt-in and only runs after the repo has been pushed to GitHub.
- Updates `context-guide.md` with a `decisions/` section and clarifies how ADRs relate to `ideas.md` / `research.md`.
- Bumps the project plugin to `0.4.0` (minor: meaningful new scaffold + script) and the marketplace to `0.14.1` (patch).

## Test plan
- [x] Ran `project-init-templates` against a fresh tmp dir; `.context/decisions/{0000-template.md,README.md}` created.
- [x] Re-ran against the same dir; all existing paths skipped, no duplication.
- [x] `shellcheck` clean on `project-init-templates` and `project-init-labels`.
- [ ] CI green on this branch.