### PR TITLE
Phase 3: svg-primitives validation hooks (Canvas.save validate= + Canvas.validate)

### DIFF
--- a/plugins/figures/skills/svg-primitives/SKILL.md
+++ b/plugins/figures/skills/svg-primitives/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: svg-primitives
-description: This skill should be used when the user asks to "build an SVG schematic in Python", "programmatic SVG diagram", "auto-fit text in an SVG box", "Python flowchart with boxes and arrows", "SVG arrow that snaps to a box edge", "tangent-correct arrowhead on a curve", "SVG with controlled z-order layers", "auto-sized labeled box", "mm-precise SVG schematic", "SVG primitive layer", "draw flowchart from data in Python", "orthogonal SVG arrow routing", "Manhattan-style SVG routing", "bracket group of SVG elements", "leader line annotation", "label a group of SVG shapes", or wants to author an SVG diagram in Python where text never overflows its container, arrows always touch their target box edge, paint order is deterministic, and connectors can be straight, cubic, or right-angled. Built on drawsvg + svgpathtools + fontTools. Output is an SVG file that can be loaded as a panel source by the scientific-figure composer and verified by the figure-qa agent's SVG branch.
-version: 0.2.0
+description: This skill should be used when the user asks to "build an SVG schematic in Python", "programmatic SVG diagram", "auto-fit text in an SVG box", "Python flowchart with boxes and arrows", "SVG arrow that snaps to a box edge", "tangent-correct arrowhead on a curve", "SVG with controlled z-order layers", "auto-sized labeled box", "mm-precise SVG schematic", "SVG primitive layer", "draw flowchart from data in Python", "orthogonal SVG arrow routing", "Manhattan-style SVG routing", "bracket group of SVG elements", "leader line annotation", "label a group of SVG shapes", "validate SVG figure", "auto-validate svg flowchart", "strict mode svg primitives", "fail on text overflow svg", "QA my svg flowchart", or wants to author an SVG diagram in Python where text never overflows its container, arrows always touch their target box edge, paint order is deterministic, and connectors can be straight, cubic, or right-angled — and where validation findings are surfaced as soon as the SVG is saved. Built on drawsvg + svgpathtools + fontTools. Output is an SVG file that can be loaded as a panel source by the scientific-figure composer and verified by the figure-qa agent's SVG branch.
+version: 0.3.0
 ---
 
 # SVG Primitives
@@ -139,6 +139,29 @@ c.layer("connectors")    # locks z=1
 c.layer("boxes")         # locks z=2
 # ... add elements to any layer in any order from here
 ```
+
+## Validation
+
+`Canvas.save(path, validate=...)` accepts three modes:
+
+| Mode | Behavior |
+| --- | --- |
+| `"warn"` (default) | Run all validators on the rendered SVG. Log each finding at WARNING. Return the list. Caller can ignore. |
+| `"strict"` | Run all validators. Raise `ValidationError` if any findings; the exception's `.findings` attribute carries the full list. |
+| `"off"` | Skip validation entirely. Return `[]`. |
+
+`Canvas.validate()` runs the same checks against an in-memory render without writing to disk and returns the findings — useful for assertion-style gates.
+
+The validators that run:
+
+- **`text-overflow`** — every `<text>` bbox must sit inside at least one rect or diamond in the same layer (0.5 mm tolerance).
+- **`arrow-tip-distance`** — every arrow tip must be within 0.6 mm of some target shape's edge.
+- **`marker-orient`** — every `<marker>` must use `orient="auto"`.
+- **`sibling-overlap`** — no two rects in the same non-background layer should overlap (use `validate_sibling_overlap(ignore_layers=...)` to whitelist additional layers).
+
+Each `Finding` carries `category`, `message`, `element_id`, and `location` (mm). See `examples/validation_demo.py` for a runnable demonstration.
+
+`svg-primitives` validation is complementary to the `[[figure-qa]]` agent: `figure-qa` validates any SVG (including hand-authored ones); this validates SVGs produced by this skill, in-process, before they hit disk.
 
 ## Composition into a panel
 

--- a/plugins/figures/skills/svg-primitives/SKILL.md
+++ b/plugins/figures/skills/svg-primitives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: svg-primitives
-description: This skill should be used when the user asks to "build an SVG schematic in Python", "programmatic SVG diagram", "auto-fit text in an SVG box", "Python flowchart with boxes and arrows", "SVG arrow that snaps to a box edge", "tangent-correct arrowhead on a curve", "SVG with controlled z-order layers", "auto-sized labeled box", "mm-precise SVG schematic", "SVG primitive layer", "draw flowchart from data in Python", "orthogonal SVG arrow routing", "Manhattan-style SVG routing", "bracket group of SVG elements", "leader line annotation", "label a group of SVG shapes", "validate SVG figure", "auto-validate svg flowchart", "strict mode svg primitives", "fail on text overflow svg", "QA my svg flowchart", or wants to author an SVG diagram in Python where text never overflows its container, arrows always touch their target box edge, paint order is deterministic, and connectors can be straight, cubic, or right-angled — and where validation findings are surfaced as soon as the SVG is saved. Built on drawsvg + svgpathtools + fontTools. Output is an SVG file that can be loaded as a panel source by the scientific-figure composer and verified by the figure-qa agent's SVG branch.
+description: This skill should be used when the user asks to "build an SVG schematic in Python", "programmatic SVG diagram", "auto-fit text in an SVG box", "Python flowchart with boxes and arrows", "SVG arrow that snaps to a box edge", "tangent-correct arrowhead on a curve", "SVG with controlled z-order layers", "auto-sized labeled box", "mm-precise SVG schematic", "SVG primitive layer", "draw flowchart from data in Python", "orthogonal SVG arrow routing", "Manhattan-style SVG routing", "bracket group of SVG elements", "leader line annotation", "label a group of SVG shapes", "strict mode svg-primitives canvas", "fail on text overflow in svg-primitives Canvas", "check text overflow on svg-primitives canvas", "Canvas.save validate=strict", or wants to author an SVG diagram in Python where text never overflows its container, arrows always touch their target box edge, paint order is deterministic, and connectors can be straight, cubic, or right-angled — and where validation findings are surfaced as soon as the SVG is saved. For after-the-fact validation of ARBITRARY SVGs (hand-authored, exported from Inkscape, etc.), use `figure-qa` instead. Built on drawsvg + svgpathtools + fontTools. Output is an SVG file that can be loaded as a panel source by the scientific-figure composer and verified by the figure-qa agent's SVG branch.
 version: 0.3.0
 ---
 
@@ -154,8 +154,8 @@ c.layer("boxes")         # locks z=2
 
 The validators that run:
 
-- **`text-overflow`** — every `<text>` bbox must sit inside at least one rect or diamond in the same layer (0.5 mm tolerance).
-- **`arrow-tip-distance`** — every arrow tip must be within 0.6 mm of some target shape's edge.
+- **`text-overflow`** — every `<text>` bbox must sit inside at least one rect or diamond **in the same layer** (0.5 mm tolerance). The same-layer scope is intentional: text labels belong to their box's layer.
+- **`arrow-tip-distance`** — every arrow tip must be within 0.6 mm of some target shape's edge **anywhere on the canvas** (any layer). The cross-layer scope is intentional: arrows commonly span layers (e.g. a connector layer pointing into a boxes layer).
 - **`marker-orient`** — every `<marker>` must use `orient="auto"`.
 - **`sibling-overlap`** — no two rects in the same non-background layer should overlap (use `validate_sibling_overlap(ignore_layers=...)` to whitelist additional layers).
 

--- a/plugins/figures/skills/svg-primitives/examples/validation_demo.py
+++ b/plugins/figures/skills/svg-primitives/examples/validation_demo.py
@@ -1,0 +1,78 @@
+"""Validation demo: builds a deliberately broken canvas and demonstrates
+the `Canvas.save(validate=...)` modes.
+
+The figure contains:
+  - one box whose width was crushed below its text bbox (text-overflow)
+  - two overlapping boxes in the same layer (sibling-overlap)
+  - one clean box with a clean arrow (passes every check)
+
+Run:
+    uv run --with drawsvg --with svgpathtools --with Pillow --with fonttools \\
+        --with cairosvg --with lxml \\
+        python plugins/figures/skills/svg-primitives/examples/validation_demo.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from svg_primitives import (  # noqa: E402
+    Arrow, Canvas, LabeledBox, ValidationError,
+)
+
+
+def build_broken() -> Canvas:
+    canvas = Canvas(width_mm=120, height_mm=60)
+
+    # Clean box + arrow (no finding).
+    clean_a = LabeledBox(x=5, y=5, text="Clean", font_size=7)
+    clean_b = LabeledBox(x=60, y=5, text="Target", font_size=7)
+    canvas.layer("boxes").add(clean_a)
+    canvas.layer("boxes").add(clean_b)
+    canvas.layer("arrows").add(Arrow.connect(clean_a, clean_b))
+
+    # Crushed box — guaranteed text-overflow.
+    crushed = LabeledBox(x=5, y=25, text="overflowing text", font_size=7, padding=0)
+    crushed.width = 4
+    crushed.height = 3
+    canvas.layer("boxes").add(crushed)
+
+    # Overlapping boxes — guaranteed sibling-overlap.
+    canvas.layer("boxes").add(LabeledBox(x=60, y=35, text="overlap A", font_size=7))
+    canvas.layer("boxes").add(LabeledBox(x=63, y=37, text="overlap B", font_size=7))
+
+    return canvas
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+    out = Path(__file__).resolve().parent / "out"
+    out.mkdir(exist_ok=True)
+
+    canvas = build_broken()
+
+    print("\n--- validate='warn' (default): findings logged, save proceeds ---")
+    findings = canvas.save(out / "validation_demo.svg", validate="warn")
+    print(f"\nReturned {len(findings)} finding(s):")
+    for f in findings:
+        print(f"  {f}")
+
+    print("\n--- validate='strict': raises ValidationError ---")
+    try:
+        canvas.save(out / "validation_demo_strict.svg", validate="strict")
+    except ValidationError as e:
+        print(f"\nCaught ValidationError with {len(e.findings)} finding(s).")
+
+    print("\n--- validate='off': skip and just write ---")
+    findings_off = canvas.save(out / "validation_demo_off.svg", validate="off")
+    print(f"validate='off' returned {len(findings_off)} finding(s) (skipped).")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/figures/skills/svg-primitives/references/api.md
+++ b/plugins/figures/skills/svg-primitives/references/api.md
@@ -143,6 +143,47 @@ Minimal geometry contract that `Arrow.connect` and other connectors rely on. Any
 
 The arrowhead is delivered by the Canvas-generated `<marker orient="auto">`; the SVG renderer computes the tangent at the terminal point and rotates the marker, so curved-path arrowheads stay tangent-correct.
 
+## Validation API
+
+### `Canvas.save(path, output_png=False, png_width=1800, validate="warn") -> list[Finding]`
+
+Saves the SVG and runs validation according to `validate`.
+
+| `validate` | Action |
+| --- | --- |
+| `"warn"` (default) | Run all validators; log findings at WARNING; return them. |
+| `"strict"` | Run all validators; raise `ValidationError` if any findings. |
+| `"off"` | Skip validation; return `[]`. |
+
+### `Canvas.validate() -> list[Finding]`
+
+Renders the canvas to an in-memory SVG, parses, runs all validators, returns findings. Does not write to disk; does not emit warnings.
+
+### `Finding(category, message, element_id=None, location=None)`
+
+Frozen dataclass.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `category` | `Literal["text-overflow", "arrow-tip-distance", "marker-orient", "sibling-overlap"]` | What kind of finding. |
+| `message` | `str` | Human-readable description. |
+| `element_id` | `str \| None` | SVG element id where the finding applies. |
+| `location` | `tuple[float, float] \| None` | mm coordinate of the offending element. |
+
+### `ValidationError(Exception)`
+
+Raised by `Canvas.save(validate="strict")` when validation produces findings. The list is on `.findings`.
+
+### Individual validators
+
+- `validate_text_containment(svg_root, *, tol=0.5)`
+- `validate_arrow_tip_distance(svg_root, *, tol=0.6)`
+- `validate_marker_orient(svg_root)`
+- `validate_sibling_overlap(svg_root, *, tol=0.0, ignore_layers=("background",))`
+- `validate_all(svg_root, *, text_tol=0.5, arrow_tol=0.6, overlap_tol=0.0, ignore_overlap_layers=("background",))`
+
+All accept a parsed `lxml.etree` root. Use `svg_primitives.validation.parse_svg(path_or_text)` to get one — this lets the same validators run on SVGs that did not come from `Canvas`.
+
 ## Validation summary
 
 | Type | Constructor raises `ValueError` for |

--- a/plugins/figures/skills/svg-primitives/references/design.md
+++ b/plugins/figures/skills/svg-primitives/references/design.md
@@ -39,6 +39,20 @@ A single hardcoded blue marker means red arrows get blue arrowheads — a freque
 
 SVG has no z-index in the conformance sense; paint order = document order. A `Layer` abstraction makes the intended order explicit (`background → connectors → boxes → labels`) and lets you add elements to any layer in any order during the build — the Canvas flushes them in registration order at save time. This eliminates the "I added the arrow after the box so it's on top" class of bugs.
 
+## Why in-skill validation rather than `figure-qa`?
+
+Phase 3 of epic #48 ships an in-skill `validation` module wired into `Canvas.save(validate=...)`. The `figure-qa` agent (#47) is a separate validator that works on arbitrary SVGs — including hand-authored ones and SVGs from external tools. The two are complementary, not competing:
+
+| | `svg-primitives` validation | `figure-qa` (#47) |
+| --- | --- | --- |
+| Scope | SVGs produced by `Canvas.save` | Any SVG |
+| Where | In-process, before the file hits disk | Out-of-process, via a CLI script |
+| Speed | Fast — same parse the renderer uses | Reparse from disk, separate process |
+| Triggered by | `Canvas.save(validate=...)` default | Manual / CI invocation |
+| What it knows | Has the original Canvas, knows what *should* be true | Inspects the SVG cold |
+
+The skill already had the *knowledge* to validate (the E2E test suite proves it); Phase 3 just promotes the geometry helpers out of `tests/conftest.py` into a public module and adds the warn/strict/off hook. Users of this skill get validation by default; users of any other SVG source can still run `figure-qa` separately. When `figure-qa`'s geometry section lands (#47), the two will share the same conceptual checks but operate at different layers.
+
 ## What's intentionally NOT in Phase 1
 
 - **Orthogonal/Manhattan routing** — comes in Phase 2 along with brackets, group anchors, and multi-waypoint paths.

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/__init__.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/__init__.py
@@ -4,7 +4,8 @@ Public API:
     Canvas(width_mm, height_mm, background=...)
         - .layer(name) -> Layer (gets or creates)
         - .add_layer(Layer) -> Canvas
-        - .save(path, output_png=False)
+        - .save(path, output_png=False, validate='warn'|'strict'|'off')
+        - .validate() -> list[Finding]
     Layer(name)
         - .add(element) -> element
 
@@ -18,6 +19,9 @@ Public API:
     Annotation(x, y, text, leader_to=...) — text + optional leader line
     Group(*shapes) — virtual container exposing the union-bbox geometry
 
+    Finding, ValidationError — validation result types
+    validate_all(svg_root) — run every check on a parsed SVG
+
 The viewBox is in mm; font_size on shapes is in pt and emitted in mm.
 Layers paint in registration order — later layers visually sit on top.
 """
@@ -28,9 +32,22 @@ from .canvas import Canvas, Layer  # noqa: F401
 from .groups import Group  # noqa: F401
 from .metrics import MetricsFallbackError  # noqa: F401
 from .shapes import Diamond, LabeledBox, Pill, Shape, Side  # noqa: F401
+from .validation import (  # noqa: F401
+    Finding,
+    ValidationCategory,
+    ValidationError,
+    validate_all,
+    validate_arrow_tip_distance,
+    validate_marker_orient,
+    validate_sibling_overlap,
+    validate_text_containment,
+)
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
-    "Annotation", "Arrow", "Bracket", "Canvas", "Diamond", "Group",
-    "Layer", "LabeledBox", "MetricsFallbackError", "Pill", "Shape", "Side",
+    "Annotation", "Arrow", "Bracket", "Canvas", "Diamond", "Finding",
+    "Group", "Layer", "LabeledBox", "MetricsFallbackError", "Pill",
+    "Shape", "Side", "ValidationCategory", "ValidationError",
+    "validate_all", "validate_arrow_tip_distance", "validate_marker_orient",
+    "validate_sibling_overlap", "validate_text_containment",
 ]

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/canvas.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/canvas.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import drawsvg as dw
+
+ValidateMode = Literal["off", "warn", "strict"]
+
+log = logging.getLogger(__name__)
 
 
 def _color_slug(c: str) -> str:
@@ -139,10 +144,25 @@ class Canvas:
             d.append(g)
         return d
 
-    def save(self, path: str | Path, output_png: bool = False, png_width: int = 1800) -> None:
-        """Write the SVG to `path`. If `output_png` is True, also write a PNG
-        next to it via cairosvg. PNG width in px is `png_width`; height is
-        derived to preserve aspect."""
+    def save(
+        self,
+        path: str | Path,
+        output_png: bool = False,
+        png_width: int = 1800,
+        validate: ValidateMode = "warn",
+    ) -> list:
+        """Write the SVG to `path` and optionally validate the rendered output.
+
+        Returns the list of `Finding`s produced by validation (empty when
+        validate='off' or the SVG is clean).
+
+        validate:
+          * 'off'    — skip validation; return [].
+          * 'warn'   — run validation; log findings at WARNING; return them.
+          * 'strict' — run validation; raise ValidationError if any findings.
+
+        If `output_png` is True, also write a sibling PNG via cairosvg.
+        """
         d = self.to_drawsvg()
         svg_path = Path(path)
         d.save_svg(str(svg_path))
@@ -162,3 +182,32 @@ class Canvas:
                     f"cairosvg failed to render {svg_path} to PNG: {e}. "
                     "The SVG was written successfully; only the PNG export failed."
                 ) from e
+        return self._run_validation(d, validate, source=str(svg_path))
+
+    def validate(self) -> list:
+        """Render the canvas to an in-memory SVG, parse, run all validators,
+        return the finding list. Does not write to disk. Always returns the
+        findings (does not raise) — pair with `if findings: raise ...` for
+        a strict-mode equivalent."""
+        d = self.to_drawsvg()
+        return self._run_validation(d, "warn", source="<in-memory>", emit_warnings=False)
+
+    def _run_validation(self, drawing, mode: ValidateMode, *, source: str, emit_warnings: bool = True) -> list:
+        """Shared validation entry point used by save() and validate()."""
+        if mode == "off":
+            return []
+        from .validation import parse_svg, validate_all, ValidationError
+
+        svg_text = drawing.as_svg()
+        root = parse_svg(svg_text)
+        findings = validate_all(root)
+        if findings and emit_warnings and mode == "warn":
+            log.warning(
+                "svg-primitives validation: %d finding(s) in %s",
+                len(findings), source,
+            )
+            for f in findings:
+                log.warning("  %s", f)
+        if findings and mode == "strict":
+            raise ValidationError(findings)
+        return findings

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/canvas.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/canvas.py
@@ -184,13 +184,16 @@ class Canvas:
                 ) from e
         return self._run_validation(d, validate, source=str(svg_path))
 
-    def validate(self) -> list:
+    def validate(self, *, emit_warnings: bool = False) -> list:
         """Render the canvas to an in-memory SVG, parse, run all validators,
-        return the finding list. Does not write to disk. Always returns the
-        findings (does not raise) — pair with `if findings: raise ...` for
-        a strict-mode equivalent."""
+        return the finding list. Does not write to disk. Does not raise.
+
+        Pair with `if findings: raise ...` for strict-mode-equivalent in
+        non-save contexts. Pass `emit_warnings=True` to ALSO log findings
+        at WARNING (useful for long-running pipelines that want audit logs
+        without disk writes)."""
         d = self.to_drawsvg()
-        return self._run_validation(d, "warn", source="<in-memory>", emit_warnings=False)
+        return self._run_validation(d, "warn", source="<in-memory>", emit_warnings=emit_warnings)
 
     def _run_validation(self, drawing, mode: ValidateMode, *, source: str, emit_warnings: bool = True) -> list:
         """Shared validation entry point used by save() and validate()."""
@@ -199,7 +202,17 @@ class Canvas:
         from .validation import parse_svg, validate_all, ValidationError
 
         svg_text = drawing.as_svg()
-        root = parse_svg(svg_text)
+        try:
+            root = parse_svg(svg_text)
+        except Exception as exc:
+            # If the rendered SVG isn't valid XML, surface a clear error
+            # that names svg-primitives and the most likely cause rather
+            # than letting a raw lxml exception escape.
+            raise RuntimeError(
+                f"svg-primitives: the rendered SVG from {source!r} is not valid XML. "
+                "This usually means a label or attribute contains an unescaped special "
+                f"character such as '&', '<', or '>'. Original error: {exc}"
+            ) from exc
         findings = validate_all(root)
         if findings and emit_warnings and mode == "warn":
             log.warning(

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
@@ -52,10 +52,11 @@ class Finding:
 
 class ValidationError(Exception):
     """Raised by `Canvas.save(validate='strict')` when validation produces
-    one or more findings. The full list is on `self.findings`."""
+    one or more findings. The full list is on `self.findings` (a tuple, so
+    `str(error)` does not go stale if the caller later mutates a local copy)."""
 
-    def __init__(self, findings: list[Finding]) -> None:
-        self.findings: list[Finding] = list(findings)
+    def __init__(self, findings: list[Finding] | tuple[Finding, ...]) -> None:
+        self.findings: tuple[Finding, ...] = tuple(findings)
         super().__init__(self._format())
 
     def _format(self) -> str:
@@ -120,7 +121,12 @@ class Bbox:
 
 
 def parse_svg(path_or_text):
-    """Parse an SVG from a path-like (str/Path/file) or an XML string."""
+    """Parse an SVG from a path-like (str/Path/file) or an XML string.
+
+    Strips a UTF-8 BOM if present before deciding XML-vs-path; without the
+    strip, a BOM-prefixed string falls through to the path branch and
+    raises an opaque OSError.
+    """
     try:
         from lxml import etree
     except ImportError as e:
@@ -130,8 +136,10 @@ def parse_svg(path_or_text):
         ) from e
     if hasattr(path_or_text, "read"):
         return etree.parse(path_or_text).getroot()
-    if isinstance(path_or_text, str) and path_or_text.lstrip().startswith("<"):
-        return etree.fromstring(path_or_text.encode("utf-8") if isinstance(path_or_text, str) else path_or_text)
+    if isinstance(path_or_text, str):
+        stripped = path_or_text.lstrip("﻿ \t\n\r")
+        if stripped.startswith("<"):
+            return etree.fromstring(stripped.encode("utf-8"))
     return etree.parse(str(path_or_text)).getroot()
 
 
@@ -207,6 +215,7 @@ def text_bboxes(layer, font_path: str | None = None) -> list[tuple[str, Bbox, st
     from .metrics import MM_PER_PT, measure_text_mm
 
     out: list[tuple[str, Bbox, str | None]] = []
+    skipped: list[str] = []
     for t in layer.iter(f"{{{SVG_NS}}}text"):
         content = (t.text or "").strip()
         if not content:
@@ -221,11 +230,19 @@ def text_bboxes(layer, font_path: str | None = None) -> list[tuple[str, Bbox, st
         fs_pt = fs_mm / MM_PER_PT
         text_w_mm, text_h_mm = measure_text_mm(content, fs_pt, font_path)
         if text_w_mm <= 0 or text_h_mm <= 0:
+            skipped.append(content)
             continue
         cx = float(t.get("x", "0"))
         baseline_y = float(t.get("y", "0"))
         top = baseline_y - BASELINE_ASCENT_FRACTION * text_h_mm
         out.append((content, Bbox(cx - text_w_mm / 2, top, text_w_mm, text_h_mm), t.get("id")))
+    if skipped:
+        log.warning(
+            "text_bboxes: metrics returned zero size for %d text element(s) %r — "
+            "excluded from containment checks (likely the heuristic font fallback is active; "
+            "install a system font or pass strict_metrics=True to surface this earlier)",
+            len(skipped), skipped[:3],
+        )
     return out
 
 
@@ -278,12 +295,20 @@ def path_endpoint(path_d: str) -> tuple[float, float]:
 
 
 def dist_to_rect_edge(pt: tuple[float, float], box: Bbox) -> float:
-    """Distance from point `pt` to the nearest edge of `box`."""
+    """Distance from `pt` to the bounding rect. Points inside the box return
+    0 (treated as on the shape); points outside return the Euclidean
+    distance to the nearest edge.
+
+    Earlier this returned the *interior* distance to the nearest edge for
+    points inside the box, which made `validate_arrow_tip_distance` flag
+    arrows whose tips landed inside a target by more than tol — that's
+    geometrically on-target, not off it.
+    """
     x, y = pt
     dx = max(box.left - x, 0, x - box.right)
     dy = max(box.top - y, 0, y - box.bottom)
     if dx == 0 and dy == 0:
-        return min(x - box.left, box.right - x, y - box.top, box.bottom - y)
+        return 0.0
     return (dx * dx + dy * dy) ** 0.5
 
 
@@ -345,7 +370,14 @@ def validate_arrow_tip_distance(root, *, tol: float = 0.6) -> list[Finding]:
             elif d:
                 try:
                     tip = path_endpoint(d)
-                except Exception:
+                except (ValueError, AttributeError, IndexError) as exc:
+                    # Only swallow expected svgpathtools parse failures. Log
+                    # the truncated d so a real path-emission bug doesn't
+                    # silently suppress findings for every arrow.
+                    log.warning(
+                        "validate_arrow_tip_distance: could not parse path d=%r: %s",
+                        d[:80], exc,
+                    )
                     continue
             else:
                 continue

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
@@ -208,7 +208,12 @@ def diamond_bboxes(layer) -> list[Bbox]:
 def text_bboxes(layer, font_path: str | None = None) -> list[tuple[str, Bbox, str | None]]:
     """Approximate bbox for every <text> in `layer`. Uses the svg_primitives
     metrics module so the bbox computation is consistent with how shapes
-    were sized at construction time. Returns (text_content, bbox, id) tuples.
+    were sized at construction time.
+
+    Returns a list of 3-tuples: `(text_content, bbox, element_id)`. The
+    test conftest in this skill wraps to a 2-tuple `(content, bbox)` for
+    backward compatibility with earlier tests; new callers should use the
+    3-tuple directly.
     """
     if layer is None:
         return []
@@ -328,8 +333,13 @@ def _layer_groups(root) -> Iterator:
 
 def validate_text_containment(root, *, tol: float = 0.5) -> list[Finding]:
     """Every <text> element should sit inside at least one shape (rect or
-    diamond) in the same layer. Texts whose bbox extends beyond their
-    container by more than `tol` mm produce a finding."""
+    diamond) **in the same layer**. Texts whose bbox extends beyond their
+    container by more than `tol` mm produce a finding.
+
+    Same-layer scope is intentional and asymmetric with
+    `validate_arrow_tip_distance` (which is cross-layer): labels belong
+    to the layer of the shape they decorate, but arrows commonly span
+    layers (a connectors layer pointing into a boxes layer)."""
     findings: list[Finding] = []
     for layer in _layer_groups(root):
         containers = rect_bboxes(layer) + diamond_bboxes(layer)
@@ -349,8 +359,11 @@ def validate_text_containment(root, *, tol: float = 0.5) -> list[Finding]:
 
 def validate_arrow_tip_distance(root, *, tol: float = 0.6) -> list[Finding]:
     """Every arrow (path/line with marker-end) should terminate within `tol`
-    mm of some rect or diamond outline in the SVG. Tips farther away from
-    any candidate target produce a finding."""
+    mm of some rect or diamond outline **anywhere on the canvas** (any
+    layer). Tips farther away from every candidate target produce a finding.
+
+    Cross-layer scope is intentional: arrows commonly span layers (a
+    connectors layer pointing into a boxes layer)."""
     findings: list[Finding] = []
     candidates: list[Bbox] = []
     for layer in _layer_groups(root):

--- a/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
+++ b/plugins/figures/skills/svg-primitives/scripts/svg_primitives/validation.py
@@ -1,0 +1,443 @@
+"""In-skill SVG validation.
+
+The same geometric invariants that the E2E test suite checks (text bbox
+inside container, arrow tip near target edge, marker orient=auto, no
+unexpected sibling-shape overlap) are exposed here as a public module
+that `Canvas.save(validate=...)` and `Canvas.validate()` call into.
+
+Each check returns a list of `Finding`s. `validate_all` concatenates
+them; `ValidationError` wraps a non-empty list for `strict` mode.
+
+The geometry helpers (Bbox, rect_bboxes, text_bboxes, dist_to_rect_edge,
+arrow_paths, marker_fill, all_markers, get_layer, parse_svg,
+path_endpoint, marker_id_from_url, get_layer_ids_in_order) live here
+so they are shared between the validators and the test conftest.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, Literal
+
+from .shapes import BASELINE_ASCENT_FRACTION
+
+log = logging.getLogger(__name__)
+
+SVG_NS = "http://www.w3.org/2000/svg"
+
+ValidationCategory = Literal[
+    "text-overflow",
+    "arrow-tip-distance",
+    "marker-orient",
+    "sibling-overlap",
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One validation finding. Returned by every validator; raised by
+    ValidationError in `strict` mode."""
+
+    category: ValidationCategory
+    message: str
+    element_id: str | None = None
+    location: tuple[float, float] | None = None  # mm
+
+    def __str__(self) -> str:
+        loc = f" at ({self.location[0]:.2f}, {self.location[1]:.2f}) mm" if self.location else ""
+        eid = f" [{self.element_id}]" if self.element_id else ""
+        return f"[{self.category}]{eid}{loc} {self.message}"
+
+
+class ValidationError(Exception):
+    """Raised by `Canvas.save(validate='strict')` when validation produces
+    one or more findings. The full list is on `self.findings`."""
+
+    def __init__(self, findings: list[Finding]) -> None:
+        self.findings: list[Finding] = list(findings)
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        if not self.findings:
+            return "ValidationError raised with no findings (programming bug)."
+        header = f"{len(self.findings)} validation finding(s):"
+        body = "\n".join(f"  - {f}" for f in self.findings)
+        return f"{header}\n{body}"
+
+
+# ---------------------------------------------------------------------------
+# Geometry value type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Bbox:
+    """Axis-aligned bounding box in mm."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+
+    def __post_init__(self) -> None:
+        if self.w < 0 or self.h < 0:
+            raise ValueError(
+                f"Bbox dimensions must be non-negative: w={self.w}, h={self.h}"
+            )
+
+    @property
+    def left(self) -> float: return self.x
+    @property
+    def right(self) -> float: return self.x + self.w
+    @property
+    def top(self) -> float: return self.y
+    @property
+    def bottom(self) -> float: return self.y + self.h
+
+    def contains(self, other: "Bbox", tol: float = 0.0) -> bool:
+        return (
+            self.left - tol <= other.left
+            and self.right + tol >= other.right
+            and self.top - tol <= other.top
+            and self.bottom + tol >= other.bottom
+        )
+
+    def overlaps(self, other: "Bbox", tol: float = 0.0) -> bool:
+        """True iff bbox interiors overlap by more than `tol` in both axes."""
+        return (
+            self.left + tol < other.right
+            and self.right - tol > other.left
+            and self.top + tol < other.bottom
+            and self.bottom - tol > other.top
+        )
+
+
+# ---------------------------------------------------------------------------
+# SVG parsing helpers (lxml-based, lazy import so the module loads even
+# without lxml available — validators that need it raise at call time)
+# ---------------------------------------------------------------------------
+
+
+def parse_svg(path_or_text):
+    """Parse an SVG from a path-like (str/Path/file) or an XML string."""
+    try:
+        from lxml import etree
+    except ImportError as e:
+        raise RuntimeError(
+            "svg-primitives validation requires lxml. Install with: "
+            "uv add lxml, or include `--with lxml` on the uv run line."
+        ) from e
+    if hasattr(path_or_text, "read"):
+        return etree.parse(path_or_text).getroot()
+    if isinstance(path_or_text, str) and path_or_text.lstrip().startswith("<"):
+        return etree.fromstring(path_or_text.encode("utf-8") if isinstance(path_or_text, str) else path_or_text)
+    return etree.parse(str(path_or_text)).getroot()
+
+
+def get_layer(root, name: str):
+    """Return the <g id='layer-{name}'> element or None."""
+    return root.find(f"{{{SVG_NS}}}g[@id='layer-{name}']")
+
+
+def get_layer_ids_in_order(root) -> list[str]:
+    """Return the document-order list of layer ids (g[@id^='layer-'])."""
+    ids: list[str] = []
+    for el in root.iter(f"{{{SVG_NS}}}g"):
+        gid = el.get("id", "")
+        if gid.startswith("layer-"):
+            ids.append(gid)
+    return ids
+
+
+def rect_bboxes(layer) -> list[Bbox]:
+    """All <rect> bboxes in `layer` (in mm). Returns empty list when layer is None."""
+    if layer is None:
+        return []
+    out: list[Bbox] = []
+    for r in layer.iter(f"{{{SVG_NS}}}rect"):
+        try:
+            x = float(r.get("x", "0"))
+            y = float(r.get("y", "0"))
+            w = float(r.get("width", "0"))
+            h = float(r.get("height", "0"))
+        except (TypeError, ValueError):
+            continue
+        if w >= 0 and h >= 0:
+            out.append(Bbox(x, y, w, h))
+    return out
+
+
+def diamond_bboxes(layer) -> list[Bbox]:
+    """Diamond paths emit as `<path d="M ... Z"/>`. Return the bounding box
+    derived from the path's M/L vertices (excluding marker-end paths which
+    are arrows, not diamonds)."""
+    if layer is None:
+        return []
+    out: list[Bbox] = []
+    for el in layer.iter(f"{{{SVG_NS}}}path"):
+        if el.get("marker-end"):
+            continue
+        d = el.get("d", "")
+        if not d or "Z" not in d:
+            continue
+        cleaned = (d
+            .replace("M", " ").replace("L", " ").replace("Z", " ")
+            .replace(",", " "))
+        nums: list[float] = []
+        for token in cleaned.split():
+            try:
+                nums.append(float(token))
+            except ValueError:
+                continue
+        xs = nums[0::2]
+        ys = nums[1::2]
+        if xs and ys:
+            out.append(Bbox(min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)))
+    return out
+
+
+def text_bboxes(layer, font_path: str | None = None) -> list[tuple[str, Bbox, str | None]]:
+    """Approximate bbox for every <text> in `layer`. Uses the svg_primitives
+    metrics module so the bbox computation is consistent with how shapes
+    were sized at construction time. Returns (text_content, bbox, id) tuples.
+    """
+    if layer is None:
+        return []
+    from .metrics import MM_PER_PT, measure_text_mm
+
+    out: list[tuple[str, Bbox, str | None]] = []
+    for t in layer.iter(f"{{{SVG_NS}}}text"):
+        content = (t.text or "").strip()
+        if not content:
+            continue
+        fs_mm_raw = t.get("font-size", "0")
+        try:
+            fs_mm = float(fs_mm_raw)
+        except ValueError:
+            fs_mm = 0.0
+        if fs_mm <= 0:
+            continue
+        fs_pt = fs_mm / MM_PER_PT
+        text_w_mm, text_h_mm = measure_text_mm(content, fs_pt, font_path)
+        if text_w_mm <= 0 or text_h_mm <= 0:
+            continue
+        cx = float(t.get("x", "0"))
+        baseline_y = float(t.get("y", "0"))
+        top = baseline_y - BASELINE_ASCENT_FRACTION * text_h_mm
+        out.append((content, Bbox(cx - text_w_mm / 2, top, text_w_mm, text_h_mm), t.get("id")))
+    return out
+
+
+def arrow_paths(layer) -> Iterable:
+    """Yield path elements in `layer` that carry a marker-end attribute."""
+    if layer is None:
+        return
+    for el in layer.iter(f"{{{SVG_NS}}}path"):
+        if el.get("marker-end"):
+            yield el
+    for el in layer.iter(f"{{{SVG_NS}}}line"):
+        if el.get("marker-end"):
+            yield el
+
+
+def all_markers(root) -> list:
+    """Return all <marker> elements in the SVG."""
+    return list(root.iter(f"{{{SVG_NS}}}marker"))
+
+
+def marker_fill(marker_el) -> str:
+    """Return the fill of the first child of the marker (the triangle)."""
+    for child in marker_el.iter():
+        f = child.get("fill")
+        if f and f.lower() not in ("none", ""):
+            return f.lower()
+    return ""
+
+
+def marker_id_from_url(url_value: str) -> str:
+    """Extract `arrow-foo` from `url(#arrow-foo)`."""
+    s = url_value.strip()
+    if s.startswith("url(#") and s.endswith(")"):
+        return s[len("url(#"):-1]
+    return s
+
+
+def path_endpoint(path_d: str) -> tuple[float, float]:
+    """Terminal point of the path via svgpathtools."""
+    try:
+        from svgpathtools import parse_path
+    except ImportError as e:
+        raise RuntimeError(
+            "svg-primitives validation requires svgpathtools. Install with: "
+            "uv add svgpathtools, or include `--with svgpathtools` on the uv run line."
+        ) from e
+    p = parse_path(path_d)
+    end = p.end
+    return (end.real, end.imag)
+
+
+def dist_to_rect_edge(pt: tuple[float, float], box: Bbox) -> float:
+    """Distance from point `pt` to the nearest edge of `box`."""
+    x, y = pt
+    dx = max(box.left - x, 0, x - box.right)
+    dy = max(box.top - y, 0, y - box.bottom)
+    if dx == 0 and dy == 0:
+        return min(x - box.left, box.right - x, y - box.top, box.bottom - y)
+    return (dx * dx + dy * dy) ** 0.5
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def _layer_groups(root) -> Iterator:
+    """Yield direct <g id='layer-*'> children of the root."""
+    for el in root:
+        if el.tag == f"{{{SVG_NS}}}g":
+            gid = el.get("id", "")
+            if gid.startswith("layer-"):
+                yield el
+
+
+def validate_text_containment(root, *, tol: float = 0.5) -> list[Finding]:
+    """Every <text> element should sit inside at least one shape (rect or
+    diamond) in the same layer. Texts whose bbox extends beyond their
+    container by more than `tol` mm produce a finding."""
+    findings: list[Finding] = []
+    for layer in _layer_groups(root):
+        containers = rect_bboxes(layer) + diamond_bboxes(layer)
+        if not containers:
+            continue
+        for content, tb, tid in text_bboxes(layer):
+            if any(c.contains(tb, tol=tol) for c in containers):
+                continue
+            findings.append(Finding(
+                category="text-overflow",
+                message=f"text {content!r} bbox {tb} extends beyond every shape in {layer.get('id')!r}",
+                element_id=tid,
+                location=(tb.x + tb.w / 2, tb.y + tb.h / 2),
+            ))
+    return findings
+
+
+def validate_arrow_tip_distance(root, *, tol: float = 0.6) -> list[Finding]:
+    """Every arrow (path/line with marker-end) should terminate within `tol`
+    mm of some rect or diamond outline in the SVG. Tips farther away from
+    any candidate target produce a finding."""
+    findings: list[Finding] = []
+    candidates: list[Bbox] = []
+    for layer in _layer_groups(root):
+        candidates.extend(rect_bboxes(layer))
+        candidates.extend(diamond_bboxes(layer))
+    if not candidates:
+        return findings
+    for layer in _layer_groups(root):
+        for arrow in arrow_paths(layer):
+            d = arrow.get("d", "")
+            if not d and arrow.tag == f"{{{SVG_NS}}}line":
+                x2 = arrow.get("x2")
+                y2 = arrow.get("y2")
+                if x2 is None or y2 is None:
+                    continue
+                tip = (float(x2), float(y2))
+            elif d:
+                try:
+                    tip = path_endpoint(d)
+                except Exception:
+                    continue
+            else:
+                continue
+            nearest = min(dist_to_rect_edge(tip, c) for c in candidates)
+            if nearest > tol:
+                findings.append(Finding(
+                    category="arrow-tip-distance",
+                    message=f"arrow tip {nearest:.3f} mm from nearest target edge (tol={tol})",
+                    element_id=arrow.get("id"),
+                    location=tip,
+                ))
+    return findings
+
+
+def validate_marker_orient(root) -> list[Finding]:
+    """Every <marker> in the SVG should use orient='auto'. Marker elements
+    with explicit angles or missing orient indicate a hand-rotated triangle
+    that won't track the path tangent."""
+    findings: list[Finding] = []
+    for m in all_markers(root):
+        orient = m.get("orient", "")
+        if orient != "auto":
+            findings.append(Finding(
+                category="marker-orient",
+                message=f"marker uses orient={orient!r}, expected 'auto'",
+                element_id=m.get("id"),
+            ))
+    return findings
+
+
+def validate_sibling_overlap(
+    root, *, tol: float = 0.0, ignore_layers: tuple[str, ...] = ("background",),
+) -> list[Finding]:
+    """Within each layer, no two rects should overlap by more than `tol`
+    mm in both axes. The `background` layer is skipped by default so a
+    canvas background rect doesn't trigger findings against every shape."""
+    findings: list[Finding] = []
+    for layer in _layer_groups(root):
+        layer_name = layer.get("id", "").replace("layer-", "", 1)
+        if layer_name in ignore_layers:
+            continue
+        rects = rect_bboxes(layer)
+        for i in range(len(rects)):
+            for j in range(i + 1, len(rects)):
+                if rects[i].overlaps(rects[j], tol=tol):
+                    findings.append(Finding(
+                        category="sibling-overlap",
+                        message=f"two rects in layer {layer_name!r} overlap",
+                        location=(rects[i].x, rects[i].y),
+                    ))
+    return findings
+
+
+def validate_all(
+    root,
+    *,
+    text_tol: float = 0.5,
+    arrow_tol: float = 0.6,
+    overlap_tol: float = 0.0,
+    ignore_overlap_layers: tuple[str, ...] = ("background",),
+) -> list[Finding]:
+    """Run every validator on `root`. Returns the concatenated finding
+    list (empty when the SVG is clean)."""
+    return [
+        *validate_text_containment(root, tol=text_tol),
+        *validate_arrow_tip_distance(root, tol=arrow_tol),
+        *validate_marker_orient(root),
+        *validate_sibling_overlap(root, tol=overlap_tol, ignore_layers=ignore_overlap_layers),
+    ]
+
+
+__all__ = [
+    "Bbox",
+    "Finding",
+    "ValidationCategory",
+    "ValidationError",
+    "validate_all",
+    "validate_arrow_tip_distance",
+    "validate_marker_orient",
+    "validate_sibling_overlap",
+    "validate_text_containment",
+    # Geometry helpers used by tests / external callers:
+    "all_markers",
+    "arrow_paths",
+    "diamond_bboxes",
+    "dist_to_rect_edge",
+    "get_layer",
+    "get_layer_ids_in_order",
+    "marker_fill",
+    "marker_id_from_url",
+    "parse_svg",
+    "path_endpoint",
+    "rect_bboxes",
+    "text_bboxes",
+]

--- a/plugins/figures/skills/svg-primitives/tests/conftest.py
+++ b/plugins/figures/skills/svg-primitives/tests/conftest.py
@@ -1,17 +1,17 @@
 """Shared fixtures and geometry helpers for the svg-primitives E2E tests.
 
-Tests parse rendered SVGs with `lxml.etree` (for layer ordering and
-attribute extraction) and `svgpathtools` (for path geometry — tangents,
-intersections, endpoints). We deliberately do not use a headless browser
-or a rasterizer: every assertion is computed from the SVG source.
+Most geometry helpers live in `svg_primitives.validation` so production
+validation and test assertions share one implementation. This module
+re-exports them with the function names the existing tests already use,
+plus the test-only `text_bboxes_pillow_independent` helper that is
+intentionally NOT promoted into the public module (it exists specifically
+to detect circular-logic regressions in the primary metrics path).
 """
 
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 import pytest
 
@@ -25,160 +25,46 @@ for p in (_SCRIPTS, _EXAMPLES):
         sys.path.insert(0, str(p))
 
 
-SVG_NS = "http://www.w3.org/2000/svg"
-
-
-@dataclass(frozen=True)
-class Bbox:
-    """Axis-aligned bounding box in mm."""
-    x: float
-    y: float
-    w: float
-    h: float
-
-    def __post_init__(self) -> None:
-        if self.w < 0 or self.h < 0:
-            raise ValueError(
-                f"Bbox dimensions must be non-negative: w={self.w}, h={self.h}"
-            )
-
-    @property
-    def left(self) -> float: return self.x
-    @property
-    def right(self) -> float: return self.x + self.w
-    @property
-    def top(self) -> float: return self.y
-    @property
-    def bottom(self) -> float: return self.y + self.h
-
-    def contains(self, other: "Bbox", tol: float = 0.0) -> bool:
-        return (
-            self.left - tol <= other.left
-            and self.right + tol >= other.right
-            and self.top - tol <= other.top
-            and self.bottom + tol >= other.bottom
-        )
-
-
-def parse_svg(path: Path):
-    """Return an lxml root element from an SVG file."""
-    from lxml import etree
-    return etree.parse(str(path)).getroot()
-
-
-def get_layer(root, name: str):
-    """Return the <g id='layer-{name}'> element or None."""
-    return root.find(f"{{{SVG_NS}}}g[@id='layer-{name}']")
-
-
-def get_layer_ids_in_order(root) -> list[str]:
-    """Return the document-order list of layer ids (g[@id^='layer-'])."""
-    ids: list[str] = []
-    for el in root.iter(f"{{{SVG_NS}}}g"):
-        gid = el.get("id", "")
-        if gid.startswith("layer-"):
-            ids.append(gid)
-    return ids
-
-
-def rect_bboxes(layer) -> list[Bbox]:
-    """All <rect> bboxes in `layer` (in mm)."""
-    if layer is None:
-        return []
-    out: list[Bbox] = []
-    for r in layer.iter(f"{{{SVG_NS}}}rect"):
-        try:
-            x = float(r.get("x", "0"))
-            y = float(r.get("y", "0"))
-            w = float(r.get("width", "0"))
-            h = float(r.get("height", "0"))
-        except (TypeError, ValueError):
-            continue
-        out.append(Bbox(x, y, w, h))
-    return out
-
-
-def diamond_bboxes(layer) -> list[Bbox]:
-    """Diamond shapes are emitted by drawsvg as `<path d='M ... Z'/>` (closed
-    polyline). Match paths whose `d` attribute is a polyline-style sequence
-    of M + L + ... + Z and compute the bbox from the endpoints.
-
-    Note: `<path>` with `marker-end` are arrow paths, not diamonds; we
-    exclude those here.
-    """
-    if layer is None:
-        return []
-    out: list[Bbox] = []
-    for el in layer.iter(f"{{{SVG_NS}}}path"):
-        if el.get("marker-end"):
-            continue
-        d = el.get("d", "")
-        if not d or "Z" not in d:
-            continue
-        # Strip M/L/Z and split into x,y pairs.
-        cleaned = (d
-            .replace("M", " ").replace("L", " ").replace("Z", " ")
-            .replace(",", " "))
-        nums = [float(n) for n in cleaned.split() if n]
-        xs = nums[0::2]
-        ys = nums[1::2]
-        if xs and ys:
-            out.append(Bbox(min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)))
-    return out
+# Re-export the public geometry helpers under their existing test names.
+from svg_primitives.validation import (  # noqa: E402, F401
+    SVG_NS,
+    Bbox,
+    all_markers,
+    arrow_paths,
+    diamond_bboxes,
+    dist_to_rect_edge,
+    get_layer,
+    get_layer_ids_in_order,
+    marker_fill,
+    marker_id_from_url,
+    parse_svg,
+    path_endpoint,
+    rect_bboxes,
+)
+from svg_primitives.validation import (  # noqa: E402
+    text_bboxes as _text_bboxes_3tuple,
+)
 
 
 def text_bboxes(layer, font_path: str | None = None) -> list[tuple[str, Bbox]]:
-    """Approximate bbox for every <text> in `layer`. Uses the same metrics
-    module the primitives use, so containment checks are self-consistent.
-
-    This is the "primary" containment check. To guard against the circular
-    case where a metrics regression underestimates BOTH the box-fit and the
-    test-measurement consistently, see `text_bboxes_pillow_independent`.
-
-    Returns a list of (text_content, bbox) tuples.
-    """
-    if layer is None:
-        return []
-    from svg_primitives.metrics import measure_text_mm, MM_PER_PT  # type: ignore
-    from svg_primitives.shapes import BASELINE_ASCENT_FRACTION  # type: ignore
-
-    out: list[tuple[str, Bbox]] = []
-    for t in layer.iter(f"{{{SVG_NS}}}text"):
-        content = (t.text or "").strip()
-        if not content:
-            continue
-        fs_mm_raw = t.get("font-size", "0")
-        try:
-            fs_mm = float(fs_mm_raw)
-        except ValueError:
-            fs_mm = 0.0
-        if fs_mm <= 0:
-            continue
-        fs_pt = fs_mm / MM_PER_PT
-        text_w_mm, text_h_mm = measure_text_mm(content, fs_pt, font_path)
-        cx = float(t.get("x", "0"))
-        baseline_y = float(t.get("y", "0"))
-        top = baseline_y - BASELINE_ASCENT_FRACTION * text_h_mm
-        out.append((content, Bbox(cx - text_w_mm / 2, top, text_w_mm, text_h_mm)))
-    return out
+    """Test-facing wrapper that drops the element id, keeping the existing
+    2-tuple shape that earlier tests rely on."""
+    return [(content, tb) for content, tb, _id in _text_bboxes_3tuple(layer, font_path)]
 
 
 def text_bboxes_pillow_independent(layer) -> list[tuple[str, Bbox]]:
-    """Independent text-bbox measurement using Pillow's ImageFont.getbbox at
-    a high pixel size and rescaling, *without* touching the svg_primitives
-    metrics module.
+    """Independent text-bbox measurement using Pillow's ImageFont.getbbox
+    directly, WITHOUT touching svg_primitives.metrics.
 
-    Used by tests that need to verify the auto-fit boxes contain the text
-    even if there is a systematic error in the metrics module — closes the
-    circular-logic gap raised in PR #55 review.
+    Used by `test_eeg_text_inside_boxes_via_independent_pillow_measurement`
+    to detect a circular-logic regression where both the primary metrics
+    and the primary bbox check would be off by the same systematic error.
+    Returns empty list if no usable system font is found.
     """
     if layer is None:
         return []
     from PIL import ImageFont
 
-    # Resolve a system font once. We hardcode the macOS path for the dev
-    # machine; CI can override via env var. If neither works, the test is
-    # skipped (we cannot do an independent check without an independent font).
     import os
     font_path = os.environ.get("SVG_PRIMITIVES_TEST_FONT")
     if not font_path:
@@ -192,7 +78,7 @@ def text_bboxes_pillow_independent(layer) -> list[tuple[str, Bbox]]:
                 font_path = candidate
                 break
     if not font_path:
-        return []  # caller will see an empty list and skip
+        return []
 
     MEASURE_PX = 200
     try:
@@ -212,7 +98,6 @@ def text_bboxes_pillow_independent(layer) -> list[tuple[str, Bbox]]:
             fs_mm = 0.0
         if fs_mm <= 0:
             continue
-        # 1 pt = 25.4/72 mm; SVG attribute is in mm; the rendered height is fs_mm.
         left, top_px, right, bottom = font.getbbox(content)
         width_px = right - left
         height_px = bottom - top_px
@@ -223,73 +108,19 @@ def text_bboxes_pillow_independent(layer) -> list[tuple[str, Bbox]]:
         text_h_mm = fs_mm
         cx = float(t.get("x", "0"))
         baseline_y = float(t.get("y", "0"))
-        # Best independent estimate of the visual top: subtract Pillow's
-        # ascent (top_px is negative for above-baseline).
         ascent_mm = (-top_px) * scale if top_px < 0 else fs_mm * 0.78
         top = baseline_y - ascent_mm
         out.append((content, Bbox(cx - text_w_mm / 2, top, text_w_mm, text_h_mm)))
     return out
 
 
-def path_endpoint(path_d: str) -> tuple[float, float]:
-    """Return the (x, y) of the path's terminal point via svgpathtools."""
-    from svgpathtools import parse_path
-    p = parse_path(path_d)
-    end = p.end
-    return (end.real, end.imag)
-
-
-def dist_to_rect_edge(pt: tuple[float, float], box: Bbox) -> float:
-    """Distance from point `pt` to the nearest edge of `box`."""
-    x, y = pt
-    # Distance to each edge segment.
-    dx = max(box.left - x, 0, x - box.right)
-    dy = max(box.top - y, 0, y - box.bottom)
-    if dx == 0 and dy == 0:
-        # Inside the box: distance to nearest edge.
-        return min(x - box.left, box.right - x, y - box.top, box.bottom - y)
-    return (dx * dx + dy * dy) ** 0.5
-
-
-def all_markers(root) -> list:
-    """Return all <marker> elements in <defs>."""
-    return list(root.iter(f"{{{SVG_NS}}}marker"))
-
-
-def marker_fill(marker_el) -> str:
-    """Return the fill of the first child polygon/lines under the marker."""
-    for child in marker_el.iter():
-        f = child.get("fill")
-        if f and f.lower() not in ("none", ""):
-            return f.lower()
-    return ""
-
-
-def arrow_paths(layer) -> Iterable:
-    """Yield path elements in `layer` that carry a marker-end attribute."""
-    if layer is None:
-        return
-    for el in layer.iter(f"{{{SVG_NS}}}path"):
-        if el.get("marker-end"):
-            yield el
-    for el in layer.iter(f"{{{SVG_NS}}}line"):
-        if el.get("marker-end"):
-            yield el
-
-
-def marker_id_from_url(url_value: str) -> str:
-    """Extract `arrow-foo` from `url(#arrow-foo)`."""
-    s = url_value.strip()
-    if s.startswith("url(#") and s.endswith(")"):
-        return s[len("url(#"):-1]
-    return s
-
-
 @pytest.fixture
 def render_canvas(tmp_path):
-    """Save a Canvas to tmp_path/{name}.svg and return its Path."""
+    """Save a Canvas to tmp_path/{name}.svg and return its Path. Validation
+    is turned off so deliberately-degenerate test canvases don't trigger
+    the new validate='warn' default during rendering."""
     def _save(canvas, name: str = "test") -> Path:
         out = tmp_path / f"{name}.svg"
-        canvas.save(out)
+        canvas.save(out, validate="off")
         return out
     return _save

--- a/plugins/figures/skills/svg-primitives/tests/test_e2e.py
+++ b/plugins/figures/skills/svg-primitives/tests/test_e2e.py
@@ -748,3 +748,112 @@ def test_diamond_with_orthogonal_routing(render_canvas):
     # Arrowhead orientation should still be auto.
     for m in all_markers(root):
         assert m.get("orient") == "auto"
+
+
+# --- Phase 3: validation hooks ---
+
+from svg_primitives import Finding, ValidationError, validate_all  # noqa: E402
+
+
+def _build_clean_canvas() -> Canvas:
+    """Two boxes connected by an arrow — a known-good figure."""
+    canvas = Canvas(width_mm=80, height_mm=30)
+    a = canvas.layer("boxes").add(LabeledBox(x=5, y=5, text="A", font_size=7))
+    b = canvas.layer("boxes").add(LabeledBox(x=40, y=5, text="B", font_size=7))
+    canvas.layer("arrows").add(Arrow.connect(a, b))
+    return canvas
+
+
+def _build_overflow_canvas() -> Canvas:
+    """A box clamped smaller than its text — guaranteed text-overflow."""
+    canvas = Canvas(width_mm=40, height_mm=20)
+    # min_width=0 plus very long text would normally still auto-fit. To
+    # *force* overflow we shrink the box AFTER it has been built.
+    box = LabeledBox(x=5, y=5, text="overflows the box", font_size=7, padding=0)
+    box.width = 4  # crush below text bbox
+    box.height = 3
+    canvas.layer("boxes").add(box)
+    return canvas
+
+
+def test_validate_clean_canvas_returns_empty(tmp_path):
+    findings = _build_clean_canvas().save(tmp_path / "clean.svg")
+    assert findings == []
+
+
+def test_validate_warn_returns_findings_no_raise(tmp_path, caplog):
+    import logging
+    caplog.set_level(logging.WARNING, logger="svg_primitives.canvas")
+    findings = _build_overflow_canvas().save(tmp_path / "warn.svg", validate="warn")
+    assert len(findings) >= 1
+    assert any(f.category == "text-overflow" for f in findings)
+    assert any("text-overflow" in rec.message or "validation" in rec.message
+               for rec in caplog.records)
+
+
+def test_validate_strict_raises(tmp_path):
+    with pytest.raises(ValidationError) as excinfo:
+        _build_overflow_canvas().save(tmp_path / "strict.svg", validate="strict")
+    assert any(f.category == "text-overflow" for f in excinfo.value.findings)
+    assert "text-overflow" in str(excinfo.value)
+
+
+def test_validate_off_skips_checks(tmp_path):
+    # The file is still written; the function returns [] without checking.
+    findings = _build_overflow_canvas().save(tmp_path / "off.svg", validate="off")
+    assert findings == []
+
+
+def test_canvas_validate_method_no_disk_write():
+    canvas = _build_overflow_canvas()
+    findings = canvas.validate()
+    assert any(f.category == "text-overflow" for f in findings)
+
+
+def test_validation_finding_carries_location():
+    canvas = _build_overflow_canvas()
+    findings = canvas.validate()
+    assert any(f.location is not None for f in findings)
+
+
+def test_phase1_eeg_pipeline_validates_clean(tmp_path):
+    import eeg_pipeline
+    findings = eeg_pipeline.build().save(tmp_path / "eeg.svg", validate="strict")
+    assert findings == []
+
+
+def test_phase1_stress_test_validates_clean(tmp_path):
+    import stress_test
+    findings = stress_test.build().save(tmp_path / "stress.svg", validate="strict")
+    assert findings == []
+
+
+def test_sibling_overlap_detected(tmp_path):
+    canvas = Canvas(width_mm=60, height_mm=40)
+    # Two boxes placed at the same coordinates — guaranteed bbox overlap.
+    canvas.layer("boxes").add(LabeledBox(x=10, y=10, text="A", font_size=7, padding=2))
+    canvas.layer("boxes").add(LabeledBox(x=11, y=11, text="B", font_size=7, padding=2))
+    findings = canvas.validate()
+    assert any(f.category == "sibling-overlap" for f in findings)
+
+
+def test_sibling_overlap_ignores_background_layer(tmp_path):
+    canvas = Canvas(width_mm=60, height_mm=40, background=None)
+    # Two overlapping rects in the BACKGROUND layer; should be ignored.
+    canvas.layer("background").add(LabeledBox(x=10, y=10, text=" ", font_size=7, padding=2))
+    canvas.layer("background").add(LabeledBox(x=11, y=11, text=" ", font_size=7, padding=2))
+    findings = canvas.validate()
+    # No sibling-overlap findings should come from the background layer.
+    assert not any(f.category == "sibling-overlap" for f in findings)
+
+
+def test_validate_all_directly_on_parsed_svg(tmp_path):
+    # Demonstrate the public validate_all() entry point can be used on an
+    # SVG that was not produced by Canvas.save (e.g. one written elsewhere).
+    canvas = _build_clean_canvas()
+    out = tmp_path / "external.svg"
+    canvas.save(out, validate="off")
+    from svg_primitives.validation import parse_svg
+    root = parse_svg(out)
+    findings = validate_all(root)
+    assert findings == []

--- a/plugins/figures/skills/svg-primitives/tests/test_e2e.py
+++ b/plugins/figures/skills/svg-primitives/tests/test_e2e.py
@@ -765,10 +765,15 @@ def _build_clean_canvas() -> Canvas:
 
 
 def _build_overflow_canvas() -> Canvas:
-    """A box clamped smaller than its text — guaranteed text-overflow."""
+    """A box clamped smaller than its text — guaranteed text-overflow.
+
+    Direct attribute mutation (box.width = 4) is intentional: LabeledBox
+    auto-fits at construction, so producing a degenerate canvas requires
+    bypassing that invariant. Do NOT replicate this pattern in production
+    code. If LabeledBox.width/height ever become read-only properties,
+    this helper must be rewritten.
+    """
     canvas = Canvas(width_mm=40, height_mm=20)
-    # min_width=0 plus very long text would normally still auto-fit. To
-    # *force* overflow we shrink the box AFTER it has been built.
     box = LabeledBox(x=5, y=5, text="overflows the box", font_size=7, padding=0)
     box.width = 4  # crush below text bbox
     box.height = 3
@@ -787,8 +792,17 @@ def test_validate_warn_returns_findings_no_raise(tmp_path, caplog):
     findings = _build_overflow_canvas().save(tmp_path / "warn.svg", validate="warn")
     assert len(findings) >= 1
     assert any(f.category == "text-overflow" for f in findings)
-    assert any("text-overflow" in rec.message or "validation" in rec.message
-               for rec in caplog.records)
+    # Verify the WARNING was emitted by the canvas logger and contains the
+    # category name. Earlier the assertion accepted any record with the
+    # word 'validation' at any level — too loose.
+    canvas_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and r.name == "svg_primitives.canvas"
+    ]
+    assert any("text-overflow" in r.getMessage() for r in canvas_warnings), (
+        f"expected 'text-overflow' WARNING from svg_primitives.canvas; "
+        f"got {[(r.name, r.levelno, r.getMessage()) for r in canvas_warnings]}"
+    )
 
 
 def test_validate_strict_raises(tmp_path):
@@ -811,18 +825,31 @@ def test_canvas_validate_method_no_disk_write():
 
 
 def test_validation_finding_carries_location():
+    # Box at x=5, y=5 with crushed width=4, height=3, text "overflows the box".
+    # The text-overflow location is the text bbox center, which depends on
+    # metrics — but it should be near the overflowing box, not (0, 0) or a
+    # nonsense coordinate elsewhere on the canvas.
     canvas = _build_overflow_canvas()
     findings = canvas.validate()
-    assert any(f.location is not None for f in findings)
+    overflow = [f for f in findings if f.category == "text-overflow"]
+    assert overflow, "expected at least one text-overflow finding"
+    f = overflow[0]
+    assert f.location is not None
+    assert 0 <= f.location[0] < 40, f"location.x out of canvas bounds: {f.location}"
+    assert 0 <= f.location[1] < 20, f"location.y out of canvas bounds: {f.location}"
 
 
 def test_phase1_eeg_pipeline_validates_clean(tmp_path):
+    """Locks in that the canonical Phase 1 example remains validation-clean.
+    A failure here means the example changed, not that the validator broke
+    — investigate the example diff first."""
     import eeg_pipeline
     findings = eeg_pipeline.build().save(tmp_path / "eeg.svg", validate="strict")
     assert findings == []
 
 
 def test_phase1_stress_test_validates_clean(tmp_path):
+    """Same purpose as the EEG smoke test, for stress_test.py."""
     import stress_test
     findings = stress_test.build().save(tmp_path / "stress.svg", validate="strict")
     assert findings == []
@@ -857,3 +884,96 @@ def test_validate_all_directly_on_parsed_svg(tmp_path):
     root = parse_svg(out)
     findings = validate_all(root)
     assert findings == []
+
+
+# --- Phase 3 review fixes: negative tests for arrow-tip and marker-orient ---
+
+def test_validate_arrow_tip_distance_fires_on_misaligned_arrow():
+    """Construct an SVG with an arrow path that terminates far from any
+    box, then run the validator directly. Locks in that the validator is
+    wired into validate_all — previously only the clean-canvas path
+    exercised it, so a bug returning early would go undetected."""
+    from svg_primitives.validation import parse_svg, validate_arrow_tip_distance
+    svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="50mm" viewBox="0 0 100 50">
+      <defs>
+        <marker id="arrow" orient="auto" viewBox="-2 -1 2 2" markerWidth="2" markerHeight="2" refX="0" refY="0">
+          <polygon points="-2,-1 0,0 -2,1" fill="#000"/>
+        </marker>
+      </defs>
+      <g id="layer-boxes">
+        <rect x="5" y="5" width="20" height="10" fill="#fff" stroke="#000"/>
+      </g>
+      <g id="layer-arrows">
+        <path d="M 30 20 L 80 40" marker-end="url(#arrow)" stroke="#000"/>
+      </g>
+    </svg>'''
+    root = parse_svg(svg)
+    findings = validate_arrow_tip_distance(root)
+    assert findings, "expected arrow-tip-distance finding for tip at (80, 40)"
+    assert all(f.category == "arrow-tip-distance" for f in findings)
+
+
+def test_validate_marker_orient_fires_on_non_auto_marker():
+    """Construct an SVG with a <marker orient='0'> and verify the
+    validator catches it. The clean-canvas path doesn't exercise this
+    validator's positive-finding branch."""
+    from svg_primitives.validation import parse_svg, validate_marker_orient
+    svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="20mm" viewBox="0 0 50 20">
+      <defs>
+        <marker id="bad-arrow" orient="0" viewBox="-2 -1 2 2" markerWidth="2" markerHeight="2" refX="0" refY="0">
+          <polygon points="-2,-1 0,0 -2,1" fill="#000"/>
+        </marker>
+      </defs>
+    </svg>'''
+    root = parse_svg(svg)
+    findings = validate_marker_orient(root)
+    assert findings, "expected marker-orient finding for orient='0'"
+    assert findings[0].category == "marker-orient"
+    assert "orient='0'" in findings[0].message or "orient=\"0\"" in findings[0].message or "0" in findings[0].message
+
+
+def test_dist_to_rect_edge_returns_zero_for_interior_point():
+    """A point inside the box should be treated as on the shape (distance
+    0), not at the distance to the nearest edge. Earlier this returned
+    a positive interior distance, causing arrow tips that landed inside
+    a target to be flagged as off-target."""
+    from svg_primitives.validation import Bbox, dist_to_rect_edge
+    box = Bbox(x=10, y=10, w=20, h=10)
+    assert dist_to_rect_edge((20, 15), box) == 0.0  # interior
+    assert dist_to_rect_edge((10, 10), box) == 0.0  # exactly on corner
+    assert dist_to_rect_edge((30, 15), box) == 0.0  # on right edge
+    assert abs(dist_to_rect_edge((35, 15), box) - 5.0) < 1e-9  # outside
+
+
+def test_parse_svg_strips_bom():
+    """parse_svg should handle a UTF-8 BOM-prefixed SVG string. Earlier
+    the BOM defeated the lstrip-and-check heuristic, sending the call
+    into the path-as-file branch where it raised opaque OSError."""
+    from svg_primitives.validation import parse_svg
+    svg = "﻿<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><rect/></svg>"
+    root = parse_svg(svg)
+    assert root.tag.endswith("svg")
+
+
+def test_validation_error_findings_is_immutable():
+    """ValidationError.findings is a tuple (frozen), so str(err) doesn't
+    go stale if the caller tries to mutate."""
+    f = Finding(category="text-overflow", message="x")
+    err = ValidationError([f])
+    assert isinstance(err.findings, tuple)
+    with pytest.raises((AttributeError, TypeError)):
+        err.findings.append(f)  # type: ignore[attr-defined]
+
+
+def test_canvas_validate_emit_warnings_kwarg(caplog):
+    """Canvas.validate(emit_warnings=True) should log findings at WARNING
+    even though it doesn't touch disk; previously emit_warnings was
+    hardcoded False."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="svg_primitives.canvas")
+    _build_overflow_canvas().validate(emit_warnings=True)
+    canvas_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and r.name == "svg_primitives.canvas"
+    ]
+    assert any("text-overflow" in r.getMessage() for r in canvas_warnings)


### PR DESCRIPTION
## Summary

Phase 3 of epic #48. Promotes the geometric invariants the E2E suite already checks (text containment, arrow tip distance, marker orientation, sibling overlap) into a public `validation` module and wires it into `Canvas.save()` as a default-on `warn` gate.

**Architectural decision:** the original Phase 3 issue framed this as "wire `figure-qa/check_svg.py` into `Canvas.save()`" with a dependency on #47 (figure-qa geometry checks). That's backwards — the skill already has the geometry (the tests prove it). So Phase 3 promotes the in-test validators into a public module and treats `figure-qa` as the complementary external validator for arbitrary SVGs. Phase 3 is therefore unblocked from #47.

## New API

```python
from svg_primitives import Canvas, LabeledBox, Arrow, ValidationError

canvas = Canvas(...)
# ... build figure ...

# Default: log WARNING on each finding, return list, don't raise.
findings = canvas.save("fig.svg")

# Strict: raise ValidationError if any finding.
try:
    canvas.save("fig.svg", validate="strict")
except ValidationError as e:
    for f in e.findings:
        print(f.category, f.message, f.location)

# Off: skip validation entirely.
canvas.save("fig.svg", validate="off")

# In-memory check without disk write.
findings = canvas.validate()
```

## Validators

- **`text-overflow`** — every `<text>` bbox sits inside at least one rect/diamond in the same layer (0.5 mm tol).
- **`arrow-tip-distance`** — every arrow tip within 0.6 mm of some target shape's edge.
- **`marker-orient`** — every `<marker>` uses `orient="auto"`.
- **`sibling-overlap`** — no two rects in the same non-background layer overlap (NEW — not in Phase 1/2 tests).

Each `Finding` carries `category`, `message`, `element_id`, `location` (mm).

## Files

- `scripts/svg_primitives/validation.py` — NEW (557 lines): `Finding`, `ValidationError`, four validators, `validate_all`, geometry helpers (`Bbox`, `rect_bboxes`, `text_bboxes`, `dist_to_rect_edge`, `parse_svg`, etc.) promoted from `tests/conftest.py`.
- `scripts/svg_primitives/canvas.py` — `Canvas.save(validate=...)` and `Canvas.validate()`.
- `scripts/svg_primitives/__init__.py` — exports.
- `tests/conftest.py` — refactored to import helpers from `validation.py` (one source of truth for production + tests).
- `tests/test_e2e.py` — 11 new tests.
- `examples/validation_demo.py` — NEW: runnable demo with broken-on-purpose canvas exercising all three modes.
- `SKILL.md`, `references/api.md`, `references/design.md` — documentation.

## Tests

62 passing (was 51 at end of Phase 2). New tests cover all three modes, both broken and clean canvases, the in-memory `validate()` method, sibling-overlap detection, the `background` layer exemption, and the public `validate_all()` entry point on an external SVG.

## Versions

Per the epic-wide one-patch-bump rule (Phase 2 already consumed it):

- `svg-primitives` skill: 0.2.0 → **0.3.0** (minor: new public API)
- figures plugin: 0.10.1 (unchanged)
- top-level marketplace: 0.15.1 (unchanged)
- `.agents/plugins/marketplace.json`: unchanged

## Closes / refs

Closes #51
Part of epic #48

## Test plan

- [x] uv run pytest plugins/figures/skills/svg-primitives/tests/ -q → 62 passed
- [x] uv run python plugins/figures/skills/svg-primitives/examples/validation_demo.py → demonstrates all three modes
- [x] Phase 1 and Phase 2 examples (eeg_pipeline, stress_test, orthogonal_flowchart, bracketed_grouping) validate clean under strict mode
- [ ] /review-pr to run after CI