### PR TITLE
Bump marketplace to 0.15.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Research and development plugins for literature search, grants, manuscripts, figures, presentations, project lifecycle management, and neuroinformatics",
-    "version": "0.15.5"
+    "version": "0.15.6"
   },
   "plugins": [
     {


### PR DESCRIPTION
Bumps the top-level marketplace version `0.15.5` -> `0.15.6` so installed clients pick up the presentation plugin update (v0.2.2) automatically.

Updates the version in `.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json` (the Codex `.agents/plugins/marketplace.json` carries no top-level version field). Per-plugin versions are unchanged here; presentation 0.2.2 landed in #74.