### PR TITLE
Add CITATION.cff and Zenodo metadata (v0.15.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Research and development plugins for literature search, grants, manuscripts, figures, presentations, project lifecycle management, and neuroinformatics",
-    "version": "0.15.6"
+    "version": "0.15.7"
   },
   "plugins": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,25 @@
+{
+  "title": "Research Skills",
+  "description": "A cross-agent marketplace of plugins and skills for academic research and development workflows: literature search and citation management, grant writing and review, manuscript preparation, publication figures, presentations, project lifecycle management, and neuroinformatics. Targets Claude Code, Codex, and Copilot CLI from shared skill definitions.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Shirazi, Seyed Yahya",
+      "orcid": "0000-0001-5557-259X",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego"
+    }
+  ],
+  "keywords": [
+    "claude-code",
+    "codex",
+    "copilot",
+    "research-workflows",
+    "literature-search",
+    "grant-writing",
+    "manuscript",
+    "scientific-figures",
+    "neuroinformatics"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ research-skills/
 - No mocks in tests
 - No emojis in commits or code
 
+## Releases & Citation
+- The marketplace version lives in `.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json` (the Codex `.agents/plugins/marketplace.json` carries no top-level version).
+- The repository is archived to Zenodo on every GitHub release, minting a versioned DOI under a stable concept DOI. When you bump the marketplace version for a release, also bump `version` (and `date-released`) in `CITATION.cff` and keep `.zenodo.json` in sync, then tag `vX.Y.Z` and create the GitHub release.
+- The concept DOI, added to `CITATION.cff` (`doi:`) and the README badge after the first Zenodo deposit, is stable across versions and does not change.
+
 ## Cross-agent compatibility
 - Keep shared project and marketplace instructions in AGENTS.md.
 - Keep CLAUDE.md as `@AGENTS.md`, followed only by Claude Code-specific additions.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.3.0
+message: "If you use the Research Skills marketplace in your research, please cite it using the metadata below."
+title: Research Skills
+abstract: >-
+  Research Skills is a cross-agent marketplace of plugins and skills for academic
+  research and development workflows: literature search and citation management,
+  grant writing and review, manuscript preparation, publication figures,
+  presentations, project lifecycle management, and neuroinformatics. It targets
+  Claude Code, Codex, and Copilot CLI from shared skill definitions.
+type: software
+authors:
+  - family-names: Shirazi
+    given-names: Seyed Yahya
+    orcid: "https://orcid.org/0000-0001-5557-259X"
+    affiliation:
+      name: "Swartz Center for Computational Neuroscience"
+      ror: "https://ror.org/01bt2qm76"
+repository-code: "https://github.com/neuromechanist/research-skills"
+license: BSD-3-Clause
+version: 0.15.7
+date-released: "2026-06-14"
+keywords:
+  - claude-code
+  - codex
+  - copilot
+  - research-workflows
+  - literature-search
+  - grant-writing
+  - manuscript
+  - scientific-figures
+  - neuroinformatics
+# Concept (all-versions) DOI is added after the first Zenodo release; it always
+# resolves to the latest version.


### PR DESCRIPTION
Adds `CITATION.cff` (CFF 1.3.0, structured affiliation with ROR) and `.zenodo.json` so GitHub releases are archived to Zenodo with a citable DOI. Bumps the marketplace to 0.15.7.

AGENTS.md gains a Releases & Citation section: bump `CITATION.cff` `version`/`date-released` in sync with the marketplace version on every release, keep `.zenodo.json` aligned, and note that the Zenodo concept DOI (added after the first deposit) is stable across versions.

Note: CFF 1.3.0 is the proposed schema adding `affiliation`/`ror`; GitHub accepts it. The pip `cffconvert` tool does not recognize 1.3.0 yet.