### PR TITLE
Add Zenodo concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ keywords:
   - manuscript
   - scientific-figures
   - neuroinformatics
-# Concept (all-versions) DOI is added after the first Zenodo release; it always
-# resolves to the latest version.
+# Concept (all-versions) DOI; always resolves to the latest release.
+doi: "10.5281/zenodo.20696516"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Research Skills
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696516.svg)](https://doi.org/10.5281/zenodo.20696516)
+
 Cross-agent marketplace for academic research workflows and development tooling. Install individual plugins for literature search, grant proposals, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics.
 
 ## Install


### PR DESCRIPTION
Adds the Zenodo concept DOI (10.5281/zenodo.20696516) to CITATION.cff and a DOI badge to the README. Resolves to the latest release; stable across versions.