### PR TITLE
presentation: refine course style, document apb shoot, bump 0.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "research-skills",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Claude Code plugins for academic research and development: literature search, grant writing and review, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics",
   "owner": {
     "name": "Seyed Yahya Shirazi",
@@ -71,7 +71,7 @@
     {
       "name": "presentation",
       "description": "Presentation builder: create interactive Reveal.js presentations from JSON with Mermaid diagrams, LaTeX math, code highlighting, and animated reveals",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "Seyed Yahya Shirazi",
         "email": "shirazi@ieee.org"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Research and development plugins for literature search, grants, manuscripts, figures, presentations, project lifecycle management, and neuroinformatics",
-    "version": "0.15.7"
+    "version": "0.15.8"
   },
   "plugins": [
     {
@@ -47,7 +47,7 @@
     {
       "name": "presentation",
       "description": "Presentation builder: create interactive Reveal.js presentations from JSON",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "source": "./plugins/presentation",
       "category": "research"
     },

--- a/plugins/presentation/.claude-plugin/plugin.json
+++ b/plugins/presentation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presentation",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Presentation builder: create interactive Reveal.js presentations from JSON using the Agentic Presentation Builder engine",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/presentation/.codex-plugin/plugin.json
+++ b/plugins/presentation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presentation",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Presentation builder: create interactive Reveal.js presentations from JSON using the Agentic Presentation Builder engine",
   "author": {
     "name": "Seyed Yahya Shirazi",

--- a/plugins/presentation/skills/presentation-builder/SKILL.md
+++ b/plugins/presentation/skills/presentation-builder/SKILL.md
@@ -224,6 +224,26 @@ bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 export presentati
 (cd "$APB_HOME" && bun run export -- "$(pwd)/presentation.json" --format pdf)
 ```
 
+## Step 5: QC every slide (don't skip)
+
+`validate` passes decks that still render a **blank mermaid** or **clipped code** -- the validator
+cannot see rendered output. Before shipping a deck (especially a high-stakes one), screenshot every
+slide at full HD with `shoot` and look at each one:
+
+```bash
+# zero-setup:
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 shoot presentation.json --out ./qc
+# or from the cache clone:
+(cd "$APB_HOME" && bun run shoot -- "$(pwd)/presentation.json" --out ./qc)
+```
+
+`shoot` serves the deck, drives headless Chrome through every slide, and writes one PNG per slide to
+`--out` (default 1920x1080; `--width`/`--height` to change). It disables transitions and fragments
+during capture so an unsettled slide-transform never fakes a right-edge clip and every animated
+element shows. Common fixes the QC pass catches -- avoid `mermaid` (renders blank here; use a `table`
+or an SVG `image`), keep `code` blocks to ~6 lines (height-capped), and put punchline `callout`s in
+`area: "footer"`. See `references/course-style.md` for the full list.
+
 ## Additional Resources
 
 ### Reference files

--- a/plugins/presentation/skills/presentation-builder/SKILL.md
+++ b/plugins/presentation/skills/presentation-builder/SKILL.md
@@ -17,13 +17,13 @@ Create interactive Reveal.js presentations from JSON using the [Agentic Presenta
 
 ## Prerequisites: get the builder CLI
 
-The engine ships an `apb` command (subcommands `validate`, `present`, `export`). Two ways to
-run it; pick per situation. Pin the tag (`#v0.1.6`) for reproducibility.
+The engine ships an `apb` command (subcommands `validate`, `present`, `export`, `shoot`). Two ways to
+run it; pick per situation. Pin the tag (`#v0.1.8`) for reproducibility.
 
 **Zero-setup (default, no clone).** Run straight from the repo with bunx (or npx):
 
 ```bash
-bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 validate deck.json --json
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.8 validate deck.json --json
 ```
 
 **Iterative authoring / offline (recommended when validating repeatedly).** Use a managed
@@ -33,7 +33,7 @@ once if needed, then run the `bun run` scripts from it:
 ```bash
 APB_HOME="${APB_HOME:-$HOME/.cache/agentic-presentation-builder}"
 if [ ! -d "$APB_HOME/.git" ]; then
-  git clone --branch v0.1.6 https://github.com/neuromechanist/agentic-presentation-builder.git "$APB_HOME"
+  git clone --branch v0.1.8 https://github.com/neuromechanist/agentic-presentation-builder.git "$APB_HOME"
   (cd "$APB_HOME" && bun install)
 fi
 # then, e.g.:
@@ -189,7 +189,7 @@ Run the CLI validator before serving:
 
 ```bash
 # zero-setup:
-bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 validate presentation.json --json
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.8 validate presentation.json --json
 # or from the cache clone:
 (cd "$APB_HOME" && bun run validate -- "$(pwd)/presentation.json" --json)
 ```
@@ -205,7 +205,7 @@ there is no need to copy anything into `public/`:
 
 ```bash
 # zero-setup:
-bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 present presentation.json --open
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.8 present presentation.json --open
 # or from the cache clone:
 (cd "$APB_HOME" && bun run present -- "$(pwd)/presentation.json" --open)
 ```
@@ -219,7 +219,7 @@ To produce a distributable file instead of serving, use `export` (PDF default; P
 
 ```bash
 # zero-setup:
-bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 export presentation.json --format pdf
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.8 export presentation.json --format pdf
 # or from the cache clone:
 (cd "$APB_HOME" && bun run export -- "$(pwd)/presentation.json" --format pdf)
 ```
@@ -232,7 +232,7 @@ slide at full HD with `shoot` and look at each one:
 
 ```bash
 # zero-setup:
-bunx github:neuromechanist/agentic-presentation-builder#v0.1.6 shoot presentation.json --out ./qc
+bunx github:neuromechanist/agentic-presentation-builder#v0.1.8 shoot presentation.json --out ./qc
 # or from the cache clone:
 (cd "$APB_HOME" && bun run shoot -- "$(pwd)/presentation.json" --out ./qc)
 ```

--- a/plugins/presentation/skills/presentation-builder/references/course-style.md
+++ b/plugins/presentation/skills/presentation-builder/references/course-style.md
@@ -61,17 +61,31 @@ author/affiliation (`medium`, `#475569`) → a links line (course / Discord / re
 
 ## Layout discipline
 
-- `single-column` is the default for content slides (the large majority).
-- `two-column` for comparisons and for the image+text pattern below.
+- `single-column` is the default for the **vast majority** of content slides (~90%). When in doubt, use it.
+- `two-column` is **fragile**: the right column's text frequently clips at the slide's right edge, and
+  a `callout`/element placed in `area: "content"` of a two-column slide **does not render at all**.
+  Reach for it only for a true side-by-side, and keep each side short. **For comparisons, prefer a
+  `table` in a single-column slide** -- it fills the width cleanly and never clips.
 - `title` only for the title slide and section dividers.
+- One hero visual per slide: put a figure/`image` in `area: "content"` at ~`50-70%` width (single-column).
+  Do not stuff an image into a two-column half with bullets beside it -- it cramps both.
 
 Headers are an H2 (`## …`) in `area: "header"` at `fontSize: "xl"`.
+
+**Vertical rhythm.** The content area is top-aligned and the slide's lower third is normally empty --
+that is expected, not a bug. To anchor the slide, put the closing `callout` in `area: "footer"` (see
+"Callouts carry the thesis"), which pins it to the bottom.
 
 ## Incremental bullets (the signature pattern)
 
 Bullets are **objects** (`{ text, animation }`), not plain strings, so each item reveals on its
 own click. Use sequential `index` values; lead each item with a **bold** phrase. Reveal type is
 `"fade"` for the list, and the final/punchline item switches to `"slide-up"`.
+
+**Size them `xl`.** Content bullets use `"fontSize": "xl"` -- `large`/`medium`/`small` render too
+small to read from the back of a room. Write **full sentences** (a bold lead-in plus a clause), not
+terse fragments, so each bullet fills the slide width like the real course decks. The first bullet
+often has **no** animation (shown immediately); the rest fade in.
 
 ```json
 {
@@ -85,7 +99,7 @@ own click. Use sequential `index` values; lead each item with a **bold** phrase.
       "animation": { "fragment": true, "type": "slide-up", "index": 2 } }
   ],
   "bulletStyle": "disc",
-  "style": { "fontSize": "large" },
+  "style": { "fontSize": "xl" },
   "position": { "area": "content" }
 }
 ```
@@ -146,14 +160,31 @@ resolves them automatically. Always give `image` an `alt` (the validator warns `
 Use a `callout` with `calloutType: "important"` for the slide's one-sentence core message; the
 other types (`tip`, `note`, `warning`, `info`) for asides.
 
+**Put the punchline callout in `area: "footer"`, not `content`.** The footer is bottom-aligned, so
+the callout anchors to the bottom of the slide (filling the otherwise-empty lower third) instead of
+floating in the middle. Give it a **`slide-up` fragment with the highest `index` on the slide** so it
+reveals **last**, after the bullets/figure. One callout per slide.
+
 ```json
 {
   "type": "callout",
   "calloutType": "important",
   "content": "A one-off script is a commit. A study-level analysis is a project.",
-  "position": { "area": "content", "order": 3 }
+  "position": { "area": "footer" },
+  "animation": { "fragment": true, "type": "slide-up", "index": 3 }
 }
 ```
+
+A callout placed in `area: "content"` instead sits wherever it falls in the stack (often mid-slide,
+with dead space beneath) -- and on a two-column slide it will not render at all. Footer is the home
+for the closing thought.
+
+### Persistent corner logo (institutional branding)
+To brand every slide (e.g. an institutional logo), add a small `image` in `area: "footer"`. The
+footer renders bottom-left, so the logo lands in the bottom-left corner; keep it small
+(`width: "7%"`). It is the author's house rule to carry the SCCN logo this way. (Footer images count
+toward the validator's `dense-media` heuristic on figure slides -- those warnings are expected for a
+corner logo; a first-class branding field is tracked upstream.)
 
 ## Speaker notes
 
@@ -164,14 +195,34 @@ animated reveals, then dashed talking points:
 "speakerNotes": "[Press right 3x to reveal fragments]\n\n- The Week 3 pattern, applied to research output.\n\n- Strands are horizontally parallel: scope before searching."
 ```
 
+## Reliability gotchas (verified by full-HD QC)
+
+These render-engine quirks bite silently -- always QC at full resolution before shipping.
+
+- **Avoid `mermaid` for must-see diagrams.** In this engine mermaid frequently renders with a
+  collapsed `viewBox` (`-8 -8 16 16`) because it measures the container before layout, so the SVG
+  exists in the DOM but the nodes scale off-canvas -- the diagram shows up **blank**. Use a `table`
+  (great for sequential/numbered flows) or an authored SVG `image` instead.
+- **Code blocks are height-capped (~42vh) and clip silently.** The presentation code font is large,
+  so a static slide fits only **~6-7 lines**. Keep snippets tight: prefer inline `# comments` over
+  separate comment lines, drop blank lines, and fold any prose into the `caption`. Longer code is cut
+  off at the bottom with no warning.
+- **Tables are the most robust content block** -- they fill the width, never clip horizontally, and
+  render identically in `present` and `export`. Reach for them for comparisons and structured lists.
+- **QC by rendering, not by validating.** `apb validate` passes a deck that still has a blank mermaid
+  or clipped code. Screenshot every slide at 1920x1080 (disable transitions during capture so an
+  unsettled slide-transform doesn't fake a right-edge clip) and look at each one.
+
 ## Quick checklist
 
 - [ ] `theme: "default"`, `16:9`, slide numbers + progress on
 - [ ] Title block: H1 → accent subtitle → author block → links line
-- [ ] Bullets are objects with per-item `fragment` animation; sequential `index`; bold lead-ins
-- [ ] Final bullet uses `type: "slide-up"`; the rest use `"fade"`
+- [ ] **`single-column` for ~90% of slides**; comparisons use a `table`, not two columns
+- [ ] Bullets are objects at **`fontSize: "xl"`**, full-sentence with bold lead-ins; sequential `index`
+- [ ] First bullet often un-animated; the rest `"fade"`; final bullet `"slide-up"`
+- [ ] One hero `image` per slide in `area: "content"` at ~`50-70%` (with `alt`)
 - [ ] Code blocks have a `language` and a fragment animation
-- [ ] Two-column image slides: header on top, image `left` (95%, with `alt`), bullets `right`
-- [ ] Core message lives in a `calloutType: "important"`
+- [ ] **Punchline `callout` lives in `area: "footer"`** with a `slide-up` fragment at the highest `index` (reveals last, pinned to the bottom)
+- [ ] Branding/SCCN logo: small `image` in `area: "footer"` (renders bottom-left)
 - [ ] `speakerNotes` lead with the reveal cue, then talking points
 - [ ] Validate with `apb validate deck.json --json`; clear `dense-bullets` / `fragment-overuse`


### PR DESCRIPTION
## Summary
Refines the presentation plugin's course-style guidance from a full-HD QC pass on a real deck, documents the new `apb shoot` QC command, and bumps the version.

## course-style.md
- Content bullets are `xl` (not large/medium); full-sentence with bold lead-ins.
- `single-column` is the default (~90%); two-column is fragile (right-edge clip; content-area callouts vanish) — use a `table` for comparisons.
- Punchline `callout` goes in `area: "footer"` with a `slide-up` fragment at the highest index (pins to bottom, reveals last).
- Reliability gotchas: avoid `mermaid` (renders blank — collapsed viewBox), keep `code` to ~6 lines (height-capped), QC by rendering not validating.

## SKILL.md
- Adds "Step 5: QC every slide" documenting `apb shoot`.

## Version
Plugin + marketplace entry 0.2.2 -> 0.2.3.
