### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'mkdocs.yml', 'pyproject.toml', '.github/workflows/docs.yml']
+  pull_request:
+    paths: ['docs/**', 'mkdocs.yml', 'pyproject.toml', '.github/workflows/docs.yml']
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group docs
+      - run: uv run mkdocs build --strict
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+          branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 # Generated
 *.generated.pdf
 output/
+site/
 
 # Serena
 .serena/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Cross-agent marketplace for academic research workflows and development tooling. Install individual plugins for literature search, grant proposals, manuscript preparation, figures, presentations, project lifecycle management, and neuroinformatics.
 
+> [!TIP]
+> This marketplace is taught week-by-week in the free [Agentic Research Course](https://courses.osc.earth/agentic-research/) from the Open Science Collective.
+
 ## Install
 
 ### Claude Code

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,10 +14,10 @@ A plugin is a bundle of **skills**, **hooks**, **agents**, and **MCP servers**, 
 
 A skill is one required file plus three optional folders, each loaded only when needed:
 
-- **`SKILL.md`** — the entry point, always read first when the skill triggers. Its frontmatter (`name` + `description`) is the trigger; the body is the lean, always-loaded instructions.
-- **`references/`** — detailed docs, loaded only when the skill's body points at them.
-- **`scripts/`** — code that gets executed, not read — token-free once written.
-- **`assets/`** — templates, icons, and fonts used in the skill's output.
+- **`SKILL.md`**: the entry point, always read first when the skill triggers. Its frontmatter (`name` + `description`) is the trigger; the body is the lean, always-loaded instructions.
+- **`references/`**: detailed docs, loaded only when the skill's body points at them.
+- **`scripts/`**: code that gets executed, not read; token-free once written.
+- **`assets/`**: templates, icons, and fonts used in the skill's output.
 
 In short: a skill is knowledge, packaged so it loads only when it is relevant.
 
@@ -27,7 +27,7 @@ In short: a skill is knowledge, packaged so it loads only when it is relevant.
 
 Both are triggered by the agent runtime, but they differ in where the work happens:
 
-- A **skill** loads knowledge into the conversation you're already in — the model keeps working, with the procedure in hand.
+- A **skill** loads knowledge into the conversation you're already in; the model keeps working, with the procedure in hand.
 - An **agent** is a worker with its own context window, its own tools, and (optionally) its own model. You delegate a scoped job to it; it returns a result.
 
 Reach for an agent when the work is isolated, repeatable, or runs in parallel (fan-out reviews, QA passes, background validation). A skill keeps the procedure with you when the work benefits from staying in the main conversation.
@@ -36,7 +36,7 @@ Reach for an agent when the work is isolated, repeatable, or runs in parallel (f
 
 ![Skill vs MCP: a skill teaches the agent with tools it already has; an MCP server wires in new tools to external systems](assets/diagrams/mcp-wire.svg)
 
-A skill teaches the agent using tools it already has. An **MCP (Model Context Protocol) server** gives it new tools by wiring to something outside the agent entirely — a database, a web API, a browser, or an external application like MATLAB/EEGLAB. If the job needs to reach the outside world, it's an MCP server's job, not a skill's.
+A skill teaches the agent using tools it already has. An **MCP (Model Context Protocol) server** gives it new tools by wiring to something outside the agent entirely: a database, a web API, a browser, or an external application like MATLAB/EEGLAB. If the job needs to reach the outside world, it's an MCP server's job, not a skill's.
 
 ## Cross-agent design
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+# Architecture
+
+Every plugin in this marketplace is built from the same small set of building blocks: skills, agents, and (for the tools that reach outside the agent) MCP servers. This page explains what each one is for and when to reach for which.
+
+## Plugin anatomy
+
+![Plugin ecosystem: a plugin bundles skills, hooks, agents, and MCP servers around the always-loaded CLAUDE.md/AGENTS.md and auto memory](assets/diagrams/plugin-ecosystem.svg)
+
+A plugin is a bundle of **skills**, **hooks**, **agents**, and **MCP servers**, installed alongside the always-loaded project instructions (`CLAUDE.md`/`AGENTS.md`) and, in Claude Code, auto memory. This marketplace's plugins mostly ship skills, plus a handful of bundled agents for review/QA surfaces (see [`project:pr-review-toolkit`](plugins/project.md), [`grant:grant-review`](plugins/grant.md), [`manuscript:paper-review`](plugins/manuscript.md), [`figures:figure-qa`](plugins/figures.md), and the neuroinformatics BIDS validator).
+
+## Anatomy of a skill
+
+![Anatomy of a skill: SKILL.md is the required entry point, with optional references/, scripts/, and assets/ folders loaded only when needed](assets/diagrams/skill-anatomy.svg)
+
+A skill is one required file plus three optional folders, each loaded only when needed:
+
+- **`SKILL.md`** — the entry point, always read first when the skill triggers. Its frontmatter (`name` + `description`) is the trigger; the body is the lean, always-loaded instructions.
+- **`references/`** — detailed docs, loaded only when the skill's body points at them.
+- **`scripts/`** — code that gets executed, not read — token-free once written.
+- **`assets/`** — templates, icons, and fonts used in the skill's output.
+
+In short: a skill is knowledge, packaged so it loads only when it is relevant.
+
+## Skill vs. agent
+
+![Skill vs agent: a skill loads knowledge into the current conversation; an agent is a worker with its own context window that returns a result](assets/diagrams/skill-vs-agent.svg)
+
+Both are triggered by the agent runtime, but they differ in where the work happens:
+
+- A **skill** loads knowledge into the conversation you're already in — the model keeps working, with the procedure in hand.
+- An **agent** is a worker with its own context window, its own tools, and (optionally) its own model. You delegate a scoped job to it; it returns a result.
+
+Reach for an agent when the work is isolated, repeatable, or runs in parallel (fan-out reviews, QA passes, background validation). A skill keeps the procedure with you when the work benefits from staying in the main conversation.
+
+## Skill vs. MCP
+
+![Skill vs MCP: a skill teaches the agent with tools it already has; an MCP server wires in new tools to external systems](assets/diagrams/mcp-wire.svg)
+
+A skill teaches the agent using tools it already has. An **MCP (Model Context Protocol) server** gives it new tools by wiring to something outside the agent entirely — a database, a web API, a browser, or an external application like MATLAB/EEGLAB. If the job needs to reach the outside world, it's an MCP server's job, not a skill's.
+
+## Cross-agent design
+
+Every skill in this marketplace is written once and shared across Claude Code, Codex, and Copilot CLI, with thin per-runtime manifests pointing at the same `skills/` trees. See [Cross-Agent Compatibility](cross-agent-compatibility.md) for exactly how each runtime discovers and registers plugins, skills, commands, and agents.
+
+Want to build your own plugin on top of these patterns? The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 10, "Building Your Own Plugins," walks through skills, hooks, agents, and MCP integration end to end.

--- a/docs/assets/diagrams/bids-conversion-flow.svg
+++ b/docs/assets/diagrams/bids-conversion-flow.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 320" width="1000" height="320">
+  <defs>
+    <marker id="arrowfwd" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle"><tspan font-family="monospace">/neuroinformatics:bids-conversion</tspan> -- a guided 6-step workflow</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Brain Imaging Data Structure (BIDS): one command walks raw recordings into a validated, shareable layout.</text>
+
+  <!-- Step 1: Inventory (blue) -->
+  <g>
+    <rect x="40" y="90" width="140" height="120" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.4"/>
+    <text x="110" y="114" font-family="sans-serif" font-size="12" fill="#1E40AF" font-weight="bold" text-anchor="middle">1. Inventory</text>
+    <text x="110" y="132" font-family="sans-serif" font-size="9.5" fill="#1E40AF" text-anchor="middle">source data</text>
+    <text x="110" y="172" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">formats,</text>
+    <text x="110" y="187" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">subjects,</text>
+    <text x="110" y="202" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">channels</text>
+  </g>
+
+  <!-- Step 2: Scaffold (blue) -->
+  <g>
+    <rect x="198" y="90" width="140" height="120" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.4"/>
+    <text x="268" y="114" font-family="sans-serif" font-size="12" fill="#1E40AF" font-weight="bold" text-anchor="middle">2. Scaffold</text>
+    <text x="268" y="160" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">dataset_</text>
+    <text x="268" y="174" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">description.json</text>
+    <text x="268" y="194" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">participants.tsv</text>
+  </g>
+
+  <!-- Step 3: Convert files (green) -->
+  <g>
+    <rect x="356" y="90" width="140" height="120" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="426" y="114" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">3. Convert</text>
+    <text x="426" y="130" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">files</text>
+    <text x="426" y="160" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">BrainVision,</text>
+    <text x="426" y="175" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">EEGLAB .set,</text>
+    <text x="426" y="190" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">EDF, BDF</text>
+  </g>
+
+  <!-- Step 4: JSON sidecars (green) -->
+  <g>
+    <rect x="514" y="90" width="140" height="120" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="584" y="114" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">4. JSON</text>
+    <text x="584" y="130" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">sidecars</text>
+    <text x="584" y="162" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">Sampling-</text>
+    <text x="584" y="176" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">Frequency,</text>
+    <text x="584" y="190" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">EEGReference...</text>
+  </g>
+
+  <!-- Step 5: TSV tables (green) -->
+  <g>
+    <rect x="672" y="90" width="140" height="120" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="742" y="114" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">5. TSV</text>
+    <text x="742" y="130" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold" text-anchor="middle">tables</text>
+    <text x="742" y="162" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">channels,</text>
+    <text x="742" y="177" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">events,</text>
+    <text x="742" y="192" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle">electrodes</text>
+  </g>
+
+  <!-- Step 6: Validate (blue) -->
+  <g>
+    <rect x="830" y="90" width="140" height="120" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.8"/>
+    <text x="900" y="114" font-family="sans-serif" font-size="12" fill="#1E40AF" font-weight="bold" text-anchor="middle">6. Validate</text>
+    <text x="900" y="170" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">bids-</text>
+    <text x="900" y="184" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">validator</text>
+  </g>
+
+  <!-- Forward arrows -->
+  <line x1="180" y1="150" x2="196" y2="150" stroke="#475569" stroke-width="1.4" marker-end="url(#arrowfwd)"/>
+  <line x1="338" y1="150" x2="354" y2="150" stroke="#475569" stroke-width="1.4" marker-end="url(#arrowfwd)"/>
+  <line x1="496" y1="150" x2="512" y2="150" stroke="#475569" stroke-width="1.4" marker-end="url(#arrowfwd)"/>
+  <line x1="654" y1="150" x2="670" y2="150" stroke="#475569" stroke-width="1.4" marker-end="url(#arrowfwd)"/>
+  <line x1="812" y1="150" x2="828" y2="150" stroke="#475569" stroke-width="1.4" marker-end="url(#arrowfwd)"/>
+
+  <!-- Bottom moral strip -->
+  <rect x="40" y="288" width="920" height="22" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.8"/>
+  <text x="500" y="303" font-family="sans-serif" font-size="11" fill="#1E293B" text-anchor="middle">Modalities: EEG, EMG, MEG, fMRI, behavioral.</text>
+</svg>

--- a/docs/assets/diagrams/bids-tree.svg
+++ b/docs/assets/diagrams/bids-tree.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">BIDS -- one layout, every dataset</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Brain Imaging Data Structure: predictable folders and filenames for one HBN-EEG subject</text>
+
+  <defs>
+    <marker id="arrow-bt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <!-- LEFT: directory tree card -->
+  <rect x="40" y="58" width="560" height="266" rx="6" fill="#EFF6FF" stroke="#2563EB" stroke-width="1.4"/>
+
+  <!-- Tree lines: fixed left x=58, line height 16, start y=80 -->
+  <!-- Folders in blue-dark bold, files in slate, sidecars/.json muted -->
+  <text x="58" y="80"  font-family="monospace" font-size="11.5" fill="#1E40AF" font-weight="bold">ds00XXXX/</text>
+  <text x="58" y="96"  font-family="monospace" font-size="11" fill="#475569">&#9500;&#9472; dataset_description.json</text>
+  <text x="58" y="112" font-family="monospace" font-size="11" fill="#475569">&#9500;&#9472; participants.tsv</text>
+  <text x="58" y="128" font-family="monospace" font-size="11" fill="#475569">&#9500;&#9472; README</text>
+  <text x="58" y="144" font-family="monospace" font-size="11.5" fill="#1E40AF" font-weight="bold">&#9492;&#9472; sub-NDARAB1234/</text>
+  <text x="58" y="160" font-family="monospace" font-size="11.5" fill="#1E40AF" font-weight="bold">&#160;&#160;&#160;&#9492;&#9472; eeg/</text>
+  <text x="58" y="176" font-family="monospace" font-size="11" fill="#1E293B">&#160;&#160;&#160;&#160;&#160;&#160;&#9500;&#9472; sub-..._task-surroundSupp_eeg.set</text>
+  <text x="58" y="192" font-family="monospace" font-size="11" fill="#1E293B">&#160;&#160;&#160;&#160;&#160;&#160;&#9500;&#9472; sub-..._task-surroundSupp_eeg.json</text>
+  <text x="58" y="208" font-family="monospace" font-size="11" fill="#1E293B">&#160;&#160;&#160;&#160;&#160;&#160;&#9500;&#9472; sub-..._task-surroundSupp_channels.tsv</text>
+  <text x="58" y="224" font-family="monospace" font-size="11" fill="#1E293B">&#160;&#160;&#160;&#160;&#160;&#160;&#9500;&#9472; sub-..._task-surroundSupp_events.tsv</text>
+  <text x="58" y="240" font-family="monospace" font-size="11" fill="#1E293B">&#160;&#160;&#160;&#160;&#160;&#160;&#9492;&#9472; sub-..._task-surroundSupp_events.json</text>
+
+  <!-- inline file-meaning hints, muted, right of card edge area but inside card -->
+  <text x="58" y="266" font-family="monospace" font-size="9.5" fill="#94A3B8">.set = signals  &#183;  .tsv = tables  &#183;  .json = sidecar metadata</text>
+  <text x="58" y="284" font-family="monospace" font-size="9.5" fill="#94A3B8">sub- = subject GUID  &#183;  task- = task label  &#183;  one entity per key</text>
+  <text x="58" y="306" font-family="sans-serif" font-size="10.5" fill="#1E40AF" font-weight="bold">Same folders + names in every BIDS dataset, anywhere.</text>
+
+  <!-- RIGHT: annotation chips pointing back at specific tree lines -->
+  <!-- dataset_description.json @ y96 -->
+  <rect x="700" y="84" width="252" height="30" rx="5" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.2"/>
+  <text x="710" y="98"  font-family="sans-serif" font-size="10" fill="#1E40AF" font-weight="bold">dataset_description.json</text>
+  <text x="710" y="110" font-family="sans-serif" font-size="9.5" fill="#1E40AF">name, BIDSVersion, authors, license</text>
+  <line x1="320" y1="93" x2="698" y2="99" stroke="#2563EB" stroke-width="1.1" marker-end="url(#arrow-bt)"/>
+
+  <!-- eeg.json sidecar @ y192 -->
+  <rect x="700" y="128" width="252" height="30" rx="5" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.2"/>
+  <text x="710" y="142" font-family="sans-serif" font-size="10" fill="#1E40AF" font-weight="bold">_eeg.json (sidecar)</text>
+  <text x="710" y="154" font-family="sans-serif" font-size="9.5" fill="#1E40AF">sampling rate, reference, channel count</text>
+  <line x1="430" y1="189" x2="698" y2="143" stroke="#2563EB" stroke-width="1.1" marker-end="url(#arrow-bt)"/>
+
+  <!-- channels.tsv @ y208 -->
+  <rect x="700" y="172" width="252" height="30" rx="5" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.2"/>
+  <text x="710" y="186" font-family="sans-serif" font-size="10" fill="#1E40AF" font-weight="bold">_channels.tsv</text>
+  <text x="710" y="198" font-family="sans-serif" font-size="9.5" fill="#1E40AF">name, type, units per electrode</text>
+  <line x1="446" y1="205" x2="698" y2="187" stroke="#2563EB" stroke-width="1.1" marker-end="url(#arrow-bt)"/>
+
+  <!-- events.json @ y240 -->
+  <rect x="700" y="216" width="252" height="30" rx="5" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.2"/>
+  <text x="710" y="230" font-family="sans-serif" font-size="10" fill="#1E40AF" font-weight="bold">_events.json</text>
+  <text x="710" y="242" font-family="sans-serif" font-size="9.5" fill="#1E40AF">HED annotations -- the WHAT of events</text>
+  <line x1="450" y1="237" x2="698" y2="231" stroke="#2563EB" stroke-width="1.1" marker-end="url(#arrow-bt)"/>
+
+  <!-- Bottom moral strip -->
+  <rect x="60" y="334" width="880" height="20" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="348" font-family="sans-serif" font-size="10" fill="#1E293B" text-anchor="middle">Predictable names + sidecars = tools find everything without asking you.</text>
+</svg>

--- a/docs/assets/diagrams/bids-why.svg
+++ b/docs/assets/diagrams/bids-why.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">Why BIDS -- one layout, every tool</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">A standard structure means analysis tools, validators, and archives all read your data unchanged</text>
+
+  <defs>
+    <marker id="arrow-hub" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <!-- Spokes drawn first so satellites sit on top. Hub center ~ (500,196). -->
+  <!-- Top-left: EEGLAB @ (230,108) -->
+  <line x1="335" y1="150" x2="408" y2="184" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Top-center: MNE-Python @ (500,92) -->
+  <line x1="500" y1="124" x2="500" y2="156" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Top-right: BIDS validator @ (770,108) -->
+  <line x1="665" y1="150" x2="592" y2="184" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Mid-left: BIDS Apps @ (150,196) -->
+  <line x1="250" y1="196" x2="406" y2="196" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Mid-right: OpenNeuro @ (850,196) -->
+  <line x1="750" y1="196" x2="594" y2="196" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Bottom-left: NEMAR @ (230,284) -->
+  <line x1="335" y1="242" x2="408" y2="208" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+  <!-- Bottom-right: mega-analysis @ (770,284) -->
+  <line x1="665" y1="242" x2="592" y2="208" stroke="#475569" stroke-width="1.3" marker-end="url(#arrow-hub)"/>
+
+  <!-- Central hub node (blue, emphasized) -->
+  <rect x="410" y="160" width="180" height="72" rx="8" fill="#DBEAFE" stroke="#2563EB" stroke-width="2.4"/>
+  <text x="500" y="190" font-family="sans-serif" font-size="14" fill="#1E40AF" font-weight="bold" text-anchor="middle">BIDS dataset</text>
+  <text x="500" y="210" font-family="sans-serif" font-size="9.5" fill="#1E40AF" text-anchor="middle">one predictable layout</text>
+  <text x="500" y="223" font-family="sans-serif" font-size="9.5" fill="#1E40AF" text-anchor="middle">+ machine-readable sidecars</text>
+
+  <!-- Satellite chips. width 144, height 36, centered on noted points. -->
+  <!-- EEGLAB (green) -->
+  <rect x="158" y="90" width="144" height="36" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+  <text x="230" y="106" font-family="sans-serif" font-size="11" fill="#065F46" font-weight="bold" text-anchor="middle">EEGLAB</text>
+  <text x="230" y="119" font-family="sans-serif" font-size="9" fill="#065F46" text-anchor="middle">MATLAB analysis</text>
+
+  <!-- MNE-Python (green) -->
+  <rect x="428" y="72" width="144" height="36" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+  <text x="500" y="88" font-family="sans-serif" font-size="11" fill="#065F46" font-weight="bold" text-anchor="middle">MNE-Python</text>
+  <text x="500" y="101" font-family="sans-serif" font-size="9" fill="#065F46" text-anchor="middle">Python analysis</text>
+
+  <!-- BIDS validator (amber) -->
+  <rect x="698" y="90" width="144" height="36" rx="6" fill="#FEF3C7" stroke="#D97706" stroke-width="1.4"/>
+  <text x="770" y="106" font-family="sans-serif" font-size="11" fill="#92400E" font-weight="bold" text-anchor="middle">BIDS validator</text>
+  <text x="770" y="119" font-family="sans-serif" font-size="9" fill="#92400E" text-anchor="middle">checks compliance</text>
+
+  <!-- BIDS Apps (purple) -->
+  <rect x="78" y="178" width="144" height="36" rx="6" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.4"/>
+  <text x="150" y="194" font-family="sans-serif" font-size="11" fill="#5B21B6" font-weight="bold" text-anchor="middle">BIDS Apps</text>
+  <text x="150" y="207" font-family="sans-serif" font-size="9" fill="#5B21B6" text-anchor="middle">containerized pipelines</text>
+
+  <!-- OpenNeuro (teal) -->
+  <rect x="778" y="178" width="144" height="36" rx="6" fill="#CCFBF1" stroke="#0D9488" stroke-width="1.4"/>
+  <text x="850" y="194" font-family="sans-serif" font-size="11" fill="#134E4A" font-weight="bold" text-anchor="middle">OpenNeuro</text>
+  <text x="850" y="207" font-family="sans-serif" font-size="9" fill="#134E4A" text-anchor="middle">public archive</text>
+
+  <!-- NEMAR (teal) -->
+  <rect x="158" y="266" width="144" height="36" rx="6" fill="#CCFBF1" stroke="#0D9488" stroke-width="1.4"/>
+  <text x="230" y="282" font-family="sans-serif" font-size="11" fill="#134E4A" font-weight="bold" text-anchor="middle">NEMAR</text>
+  <text x="230" y="295" font-family="sans-serif" font-size="9" fill="#134E4A" text-anchor="middle">EEG compute gateway</text>
+
+  <!-- mega-analysis (pink) -->
+  <rect x="698" y="266" width="144" height="36" rx="6" fill="#FCE7F3" stroke="#BE185D" stroke-width="1.4"/>
+  <text x="770" y="282" font-family="sans-serif" font-size="11" fill="#831843" font-weight="bold" text-anchor="middle">mega-analysis</text>
+  <text x="770" y="295" font-family="sans-serif" font-size="9" fill="#831843" text-anchor="middle">pool many datasets</text>
+
+  <!-- Bottom moral strip -->
+  <rect x="60" y="334" width="880" height="20" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="348" font-family="sans-serif" font-size="10" fill="#1E293B" text-anchor="middle">Standard structure turns 'my data' into 'reusable data'.</text>
+</svg>

--- a/docs/assets/diagrams/epic-branching.svg
+++ b/docs/assets/diagrams/epic-branching.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- main branch: thick line across the top -->
+  <line x1="18" y1="30" x2="182" y2="30" stroke="#14532D" stroke-width="2"/>
+  <circle cx="22" cy="30" r="3" fill="#14532D"/>
+  <circle cx="178" cy="30" r="3" fill="#14532D"/>
+  <text x="12" y="22" font-family="sans-serif" font-size="9" fill="#14532D" font-weight="bold">main</text>
+
+  <!-- epic branch: branches off main at x=30, returns at x=170 -->
+  <path d="M30 30 Q30 60 45 60 L155 60 Q170 60 170 30"
+        fill="none" stroke="#2563EB" stroke-width="2"/>
+  <text x="12" y="68" font-family="sans-serif" font-size="9" fill="#2563EB" font-weight="bold">epic</text>
+
+  <!-- integration test diamond on the epic rail, 15% from the right end -->
+  <g transform="translate(148 60)">
+    <polygon points="0,-5 5,0 0,5 -5,0" fill="#2563EB"/>
+  </g>
+  <text x="148" y="50" font-family="sans-serif" font-size="7" fill="#2563EB" text-anchor="middle">integration</text>
+
+  <!-- phase rails: each branches off epic, runs horizontally, merges back -->
+  <!-- P1: 45-70, y=95 -->
+  <path d="M45 60 Q45 85 55 85 L65 85 Q75 85 75 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="60" y="99" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P1</text>
+
+  <!-- P2: 60-90, y=120 -->
+  <path d="M65 60 Q65 110 75 110 L85 110 Q95 110 95 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="80" y="124" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P2</text>
+
+  <!-- P3: 80-115, y=145 -->
+  <path d="M85 60 Q85 135 95 135 L110 135 Q120 135 120 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="102" y="149" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P3</text>
+
+  <!-- P4: 100-135, y=170 -->
+  <path d="M105 60 Q105 160 115 160 L130 160 Q140 160 140 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="122" y="174" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P4</text>
+
+  <!-- P5: 120-150, y=145 -->
+  <path d="M125 60 Q125 135 135 135 L148 135 Q158 135 158 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="141" y="149" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P5</text>
+
+  <!-- P6: 135-165, y=120 -->
+  <path d="M140 60 Q140 110 150 110 L160 110 Q170 110 170 60" fill="none" stroke="#64748B" stroke-width="1.5" stroke-opacity="0"/>
+  <path d="M140 60 Q140 115 150 115 L160 115 Q165 115 165 60" fill="none" stroke="#64748B" stroke-width="1.5"/>
+  <text x="152" y="127" font-family="sans-serif" font-size="8" fill="#64748B" font-weight="bold" text-anchor="middle">P6</text>
+
+  <!-- legend at bottom -->
+  <rect x="20" y="185" width="8" height="2" fill="#14532D"/>
+  <text x="32" y="189" font-family="sans-serif" font-size="7" fill="#0F172A">main</text>
+  <rect x="60" y="185" width="8" height="2" fill="#2563EB"/>
+  <text x="72" y="189" font-family="sans-serif" font-size="7" fill="#0F172A">epic</text>
+  <rect x="100" y="185" width="8" height="2" fill="#64748B"/>
+  <text x="112" y="189" font-family="sans-serif" font-size="7" fill="#0F172A">phase</text>
+  <polygon points="145,186 148,189 145,192 142,189" fill="#2563EB"/>
+  <text x="152" y="189" font-family="sans-serif" font-size="7" fill="#0F172A">integration</text>
+</svg>

--- a/docs/assets/diagrams/figure-qa-dispatch.svg
+++ b/docs/assets/diagrams/figure-qa-dispatch.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">/figures:figure-qa -- dispatch by input type, then deterministic + VLM</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Agent detects input type, runs the right check script, adds a VLM aesthetic pass on top.</text>
+
+  <!-- LEFT: four input types -->
+  <g>
+    <text x="140" y="76" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">Input types</text>
+
+    <rect x="50" y="92" width="180" height="48" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.4"/>
+    <text x="140" y="113" font-family="sans-serif" font-size="11" fill="#1E40AF" font-weight="bold" text-anchor="middle">SVG</text>
+    <text x="140" y="130" font-family="monospace" font-size="9.5" fill="#1E40AF" text-anchor="middle">figure.svg</text>
+
+    <rect x="50" y="148" width="180" height="48" rx="6" fill="#FEF3C7" stroke="#D97706" stroke-width="1.4"/>
+    <text x="140" y="169" font-family="sans-serif" font-size="11" fill="#92400E" font-weight="bold" text-anchor="middle">Raster image</text>
+    <text x="140" y="186" font-family="monospace" font-size="9.5" fill="#92400E" text-anchor="middle">PNG / JPG / TIFF</text>
+
+    <rect x="50" y="204" width="180" height="48" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="140" y="225" font-family="sans-serif" font-size="11" fill="#065F46" font-weight="bold" text-anchor="middle">Plot script</text>
+    <text x="140" y="242" font-family="monospace" font-size="9.5" fill="#065F46" text-anchor="middle">panel_a.py</text>
+
+    <rect x="50" y="260" width="180" height="48" rx="6" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.4"/>
+    <text x="140" y="281" font-family="sans-serif" font-size="11" fill="#5B21B6" font-weight="bold" text-anchor="middle">Composed figure dir</text>
+    <text x="140" y="298" font-family="monospace" font-size="9.5" fill="#5B21B6" text-anchor="middle">figures/panel-a/</text>
+  </g>
+
+  <!-- CENTER: agent diamond -->
+  <defs>
+    <marker id="arrow-dispatch" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#BE185D"/>
+    </marker>
+  </defs>
+  <line x1="232" y1="116" x2="380" y2="170" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="3,2" marker-end="url(#arrow-dispatch)"/>
+  <line x1="232" y1="172" x2="380" y2="184" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="3,2" marker-end="url(#arrow-dispatch)"/>
+  <line x1="232" y1="228" x2="380" y2="198" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="3,2" marker-end="url(#arrow-dispatch)"/>
+  <line x1="232" y1="284" x2="380" y2="212" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="3,2" marker-end="url(#arrow-dispatch)"/>
+
+  <g>
+    <polygon points="500,140 580,190 500,240 420,190" fill="#FCE7F3" stroke="#BE185D" stroke-width="2"/>
+    <text x="500" y="186" font-family="sans-serif" font-size="11" fill="#831843" font-weight="bold" text-anchor="middle">figure-qa</text>
+    <text x="500" y="202" font-family="sans-serif" font-size="11" fill="#831843" font-weight="bold" text-anchor="middle">agent</text>
+    <text x="500" y="220" font-family="sans-serif" font-size="9.5" fill="#9D174D" font-style="italic" text-anchor="middle">dispatch</text>
+
+    <!-- no-qa opt-out badge -->
+    <rect x="442" y="252" width="116" height="22" rx="3" fill="#FFFFFF" stroke="#BE185D" stroke-width="1.2" stroke-dasharray="3,2"/>
+    <text x="500" y="267" font-family="monospace" font-size="10" fill="#831843" text-anchor="middle">no-qa opt-out</text>
+  </g>
+
+  <line x1="580" y1="180" x2="730" y2="120" stroke="#BE185D" stroke-width="1.4" marker-end="url(#arrow-dispatch)"/>
+  <line x1="580" y1="190" x2="730" y2="178" stroke="#BE185D" stroke-width="1.4" marker-end="url(#arrow-dispatch)"/>
+  <line x1="580" y1="200" x2="730" y2="236" stroke="#BE185D" stroke-width="1.4" marker-end="url(#arrow-dispatch)"/>
+  <line x1="580" y1="220" x2="730" y2="294" stroke="#BE185D" stroke-width="1.4" marker-end="url(#arrow-dispatch)"/>
+
+  <!-- RIGHT: check scripts + VLM -->
+  <g>
+    <text x="860" y="76" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">Check scripts + VLM judge</text>
+
+    <rect x="770" y="92" width="180" height="48" rx="6" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.4"/>
+    <text x="860" y="111" font-family="monospace" font-size="10.5" fill="#1E40AF" font-weight="bold" text-anchor="middle">check_svg.py</text>
+    <text x="860" y="128" font-family="sans-serif" font-size="9" fill="#475569" text-anchor="middle">bbox / arrow tip / pt / palette</text>
+
+    <rect x="770" y="148" width="180" height="48" rx="6" fill="#FFFFFF" stroke="#D97706" stroke-width="1.4"/>
+    <text x="860" y="167" font-family="monospace" font-size="10.5" fill="#92400E" font-weight="bold" text-anchor="middle">check_raster.py</text>
+    <text x="860" y="184" font-family="sans-serif" font-size="9" fill="#475569" text-anchor="middle">DPI / fonts embedded / alpha</text>
+
+    <rect x="770" y="204" width="180" height="48" rx="6" fill="#FFFFFF" stroke="#059669" stroke-width="1.4"/>
+    <text x="860" y="223" font-family="monospace" font-size="10.5" fill="#065F46" font-weight="bold" text-anchor="middle">check_plot_script.py</text>
+    <text x="860" y="240" font-family="sans-serif" font-size="9" fill="#475569" text-anchor="middle">savefig kwargs / rcparams</text>
+
+    <rect x="770" y="260" width="180" height="60" rx="6" fill="#FBCFE8" stroke="#BE185D" stroke-width="1.6"/>
+    <text x="860" y="280" font-family="sans-serif" font-size="11" fill="#831843" font-weight="bold" text-anchor="middle">VLM judgment pass</text>
+    <text x="860" y="296" font-family="sans-serif" font-size="9" fill="#9D174D" text-anchor="middle">hierarchy + layering</text>
+    <text x="860" y="310" font-family="sans-serif" font-size="9" fill="#9D174D" font-style="italic" text-anchor="middle">runs for every input type</text>
+  </g>
+
+  <!-- Bottom strip -->
+  <rect x="50" y="334" width="900" height="22" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="349" font-family="sans-serif" font-size="10.5" fill="#1E293B" text-anchor="middle">Helper scripts at figures/agents/figure-qa-scripts/. The agent locates them via $CLAUDE_PLUGIN_ROOT or a project-scoped find fallback.</text>
+</svg>

--- a/docs/assets/diagrams/figures-pipeline.svg
+++ b/docs/assets/diagrams/figures-pipeline.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 320" width="1000" height="320">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">Figure = 5-step managed pipeline (each step has a mechanical defence)</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Plan -- Build -- Compose -- Validate -- Export. Boomerang from Validate back to Build on font failure.</text>
+
+  <!-- Stage 1: Plan (blue) -->
+  <g>
+    <rect x="40" y="90" width="170" height="100" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.6"/>
+    <text x="125" y="115" font-family="sans-serif" font-size="13" fill="#1E40AF" font-weight="bold" text-anchor="middle">1. Plan</text>
+    <text x="125" y="138" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">journal size</text>
+    <text x="125" y="154" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">panel grid</text>
+    <text x="125" y="170" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">palette + theme</text>
+  </g>
+
+  <!-- Stage 2: Build (green) -->
+  <g>
+    <rect x="232" y="90" width="170" height="100" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.6"/>
+    <text x="317" y="115" font-family="sans-serif" font-size="13" fill="#065F46" font-weight="bold" text-anchor="middle">2. Build</text>
+    <text x="317" y="138" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">plot-styling</text>
+    <text x="317" y="154" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">svg-figure</text>
+    <text x="317" y="170" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">icons / substrate</text>
+  </g>
+
+  <!-- Stage 3: Compose (purple) -->
+  <g>
+    <rect x="424" y="90" width="170" height="100" rx="6" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.6"/>
+    <text x="509" y="115" font-family="sans-serif" font-size="13" fill="#5B21B6" font-weight="bold" text-anchor="middle">3. Compose</text>
+    <text x="509" y="138" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">svgutils</text>
+    <text x="509" y="154" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">exact mm coords</text>
+    <text x="509" y="170" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">text preserved</text>
+  </g>
+
+  <!-- Stage 4: Validate (amber) - the NEW defence -->
+  <g>
+    <rect x="616" y="90" width="170" height="100" rx="6" fill="#FEF3C7" stroke="#D97706" stroke-width="2"/>
+    <text x="701" y="115" font-family="sans-serif" font-size="13" fill="#92400E" font-weight="bold" text-anchor="middle">4. Validate</text>
+    <text x="701" y="138" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">validate_fonts.py</text>
+    <text x="701" y="154" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">effective pt vs</text>
+    <text x="701" y="170" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">journal minimum</text>
+    <!-- NEW badge -->
+    <rect x="744" y="76" width="42" height="16" rx="3" fill="#DC2626"/>
+    <text x="765" y="87" font-family="sans-serif" font-size="9.5" fill="#FFFFFF" font-weight="bold" text-anchor="middle">NEW</text>
+  </g>
+
+  <!-- Stage 5: Export (teal) -->
+  <g>
+    <rect x="808" y="90" width="152" height="100" rx="6" fill="#CCFBF1" stroke="#0D9488" stroke-width="1.6"/>
+    <text x="884" y="115" font-family="sans-serif" font-size="13" fill="#134E4A" font-weight="bold" text-anchor="middle">5. Export</text>
+    <text x="884" y="138" font-family="sans-serif" font-size="10" fill="#134E4A" text-anchor="middle">Inkscape</text>
+    <text x="884" y="154" font-family="sans-serif" font-size="10" fill="#134E4A" text-anchor="middle">(cairosvg</text>
+    <text x="884" y="170" font-family="sans-serif" font-size="10" fill="#134E4A" text-anchor="middle">fallback)</text>
+  </g>
+
+  <!-- Forward arrows between stages -->
+  <defs>
+    <marker id="arrowfwd" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+    <marker id="arrowback" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#DC2626"/>
+    </marker>
+  </defs>
+  <line x1="210" y1="140" x2="232" y2="140" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+  <line x1="402" y1="140" x2="424" y2="140" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+  <line x1="594" y1="140" x2="616" y2="140" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+  <line x1="786" y1="140" x2="808" y2="140" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+
+  <!-- Boomerang from Validate (4) back to Build (2) -->
+  <path d="M 701 190 C 701 250, 317 260, 317 190" fill="none" stroke="#DC2626" stroke-width="1.8" stroke-dasharray="6,3" marker-end="url(#arrowback)"/>
+  <text x="509" y="252" font-family="sans-serif" font-size="11" fill="#DC2626" font-weight="bold" text-anchor="middle">boomerang on font-validator failure</text>
+  <text x="509" y="268" font-family="sans-serif" font-size="10" fill="#7F1D1D" font-style="italic" text-anchor="middle">rescale panel up, or increase source pt, or widen canvas</text>
+
+  <!-- Bottom moral strip -->
+  <rect x="40" y="288" width="920" height="22" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.8"/>
+  <text x="500" y="303" font-family="sans-serif" font-size="11" fill="#1E293B" text-anchor="middle">Same shape as Weeks 5-7 pipelines. The validator is the new mechanical defence introduced this week.</text>
+</svg>

--- a/docs/assets/diagrams/figures-plugin-map.svg
+++ b/docs/assets/diagrams/figures-plugin-map.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">The figures plugin -- 5 skills + 1 QA agent</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Composer at the centre; four element builders feed it; the QA agent runs on every figure</text>
+
+  <!-- QA agent at top -->
+  <g>
+    <rect x="380" y="70" width="240" height="56" rx="6" fill="#FCE7F3" stroke="#BE185D" stroke-width="1.8"/>
+    <rect x="380" y="70" width="240" height="22" rx="6" fill="#FBCFE8" stroke="#BE185D" stroke-width="1.8"/>
+    <text x="500" y="86" font-family="monospace" font-size="11" fill="#831843" font-weight="bold" text-anchor="middle">/figures:figure-qa</text>
+    <text x="500" y="106" font-family="sans-serif" font-size="11" fill="#9D174D" font-weight="bold" text-anchor="middle">QA agent</text>
+    <text x="500" y="120" font-family="sans-serif" font-size="9.5" fill="#9D174D" text-anchor="middle">deterministic checks + VLM aesthetic pass</text>
+  </g>
+
+  <!-- Arrows from QA down to composer -->
+  <defs>
+    <marker id="arrow-qa" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#BE185D"/>
+    </marker>
+    <marker id="arrow-builder" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+  <line x1="450" y1="126" x2="450" y2="170" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="4,2" marker-end="url(#arrow-qa)"/>
+  <line x1="550" y1="126" x2="550" y2="170" stroke="#BE185D" stroke-width="1.4" stroke-dasharray="4,2" marker-end="url(#arrow-qa)"/>
+
+  <!-- Composer at center -->
+  <g>
+    <rect x="380" y="170" width="240" height="100" rx="6" fill="#EDE9FE" stroke="#7C3AED" stroke-width="2"/>
+    <rect x="380" y="170" width="240" height="26" rx="6" fill="#DDD6FE" stroke="#7C3AED" stroke-width="2"/>
+    <text x="500" y="188" font-family="monospace" font-size="11.5" fill="#5B21B6" font-weight="bold" text-anchor="middle">/figures:scientific-figure</text>
+    <text x="500" y="212" font-family="sans-serif" font-size="12" fill="#5B21B6" font-weight="bold" text-anchor="middle">Composer (the sink)</text>
+    <text x="500" y="230" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">svgutils, exact mm coordinates</text>
+    <text x="500" y="246" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">validate_fonts.py before export</text>
+    <text x="500" y="262" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">Inkscape / cairosvg backend</text>
+  </g>
+
+  <!-- Four element builders around composer -->
+  <!-- Top-left: plot-styling -->
+  <g>
+    <rect x="60" y="170" width="180" height="62" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="150" y="188" font-family="monospace" font-size="10" fill="#065F46" font-weight="bold" text-anchor="middle">/figures:plot-styling</text>
+    <text x="150" y="206" font-family="sans-serif" font-size="10.5" fill="#065F46" font-weight="bold" text-anchor="middle">Data plots</text>
+    <text x="150" y="222" font-family="sans-serif" font-size="9.5" fill="#065F46" text-anchor="middle">matplotlib / seaborn / SciencePlots</text>
+  </g>
+  <line x1="240" y1="201" x2="375" y2="201" stroke="#475569" stroke-width="1.2" marker-end="url(#arrow-builder)"/>
+
+  <!-- Top-right: svg-figure -->
+  <g>
+    <rect x="760" y="170" width="180" height="62" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.4"/>
+    <text x="850" y="188" font-family="monospace" font-size="10" fill="#1E40AF" font-weight="bold" text-anchor="middle">/figures:svg-figure</text>
+    <text x="850" y="206" font-family="sans-serif" font-size="10.5" fill="#1E40AF" font-weight="bold" text-anchor="middle">Schematics</text>
+    <text x="850" y="222" font-family="sans-serif" font-size="9.5" fill="#1E40AF" text-anchor="middle">boxes, arrows, labels in SVG</text>
+  </g>
+  <line x1="760" y1="201" x2="625" y2="201" stroke="#475569" stroke-width="1.2" marker-end="url(#arrow-builder)"/>
+
+  <!-- Bottom-left: transparent-icons -->
+  <g>
+    <rect x="60" y="262" width="180" height="62" rx="6" fill="#FEF3C7" stroke="#D97706" stroke-width="1.4"/>
+    <text x="150" y="280" font-family="monospace" font-size="10" fill="#92400E" font-weight="bold" text-anchor="middle">/figures:transparent-icons</text>
+    <text x="150" y="298" font-family="sans-serif" font-size="10.5" fill="#92400E" font-weight="bold" text-anchor="middle">Flat icons</text>
+    <text x="150" y="314" font-family="sans-serif" font-size="9.5" fill="#92400E" text-anchor="middle">Codex CLI image_gen / API</text>
+  </g>
+  <line x1="240" y1="293" x2="375" y2="245" stroke="#475569" stroke-width="1.2" marker-end="url(#arrow-builder)"/>
+
+  <!-- Bottom-right: ai-full-figure -->
+  <g>
+    <rect x="760" y="262" width="180" height="62" rx="6" fill="#FCE7F3" stroke="#BE185D" stroke-width="1.4"/>
+    <text x="850" y="280" font-family="monospace" font-size="10" fill="#831843" font-weight="bold" text-anchor="middle">/figures:ai-full-figure</text>
+    <text x="850" y="298" font-family="sans-serif" font-size="10.5" fill="#831843" font-weight="bold" text-anchor="middle">Pictorial substrates</text>
+    <text x="850" y="314" font-family="sans-serif" font-size="9.5" fill="#831843" text-anchor="middle">substrate + programmatic overlay</text>
+  </g>
+  <line x1="760" y1="293" x2="625" y2="245" stroke="#475569" stroke-width="1.2" marker-end="url(#arrow-builder)"/>
+
+  <!-- Bottom moral strip -->
+  <rect x="60" y="334" width="880" height="20" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="348" font-family="sans-serif" font-size="10" fill="#1E293B" text-anchor="middle">Plugin expanded between Weeks 7 and 8: was 3 skills, now 5 skills + 1 QA agent.</text>
+</svg>

--- a/docs/assets/diagrams/grant-boomerang.svg
+++ b/docs/assets/diagrams/grant-boomerang.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 340" width="960" height="340">
+  <text x="480" y="26" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">/grant:grant-review boomerang -- findings cycle into the right stage</text>
+
+  <!-- Pipeline track -->
+  <g>
+    <!-- 5 stage circles, smaller -->
+    <circle cx="120" cy="190" r="36" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.8"/>
+    <text x="120" y="195" font-family="sans-serif" font-size="11" fill="#1E40AF" font-weight="bold" text-anchor="middle">NOFO</text>
+
+    <circle cx="270" cy="190" r="36" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.8"/>
+    <text x="270" y="195" font-family="sans-serif" font-size="11" fill="#7C2D12" font-weight="bold" text-anchor="middle">Aims</text>
+
+    <circle cx="420" cy="190" r="36" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.8"/>
+    <text x="420" y="195" font-family="sans-serif" font-size="11" fill="#5B21B6" font-weight="bold" text-anchor="middle">Strategy</text>
+
+    <circle cx="570" cy="190" r="36" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.8"/>
+    <text x="570" y="195" font-family="sans-serif" font-size="11" fill="#991B1B" font-weight="bold" text-anchor="middle">Review</text>
+
+    <circle cx="720" cy="190" r="36" fill="#D1FAE5" stroke="#059669" stroke-width="1.8"/>
+    <text x="720" y="195" font-family="sans-serif" font-size="11" fill="#065F46" font-weight="bold" text-anchor="middle">Fig QA</text>
+
+    <path d="M156 190 L234 190" fill="none" stroke="#475569" stroke-width="2"/>
+    <polygon points="234,190 226,186 226,194" fill="#475569"/>
+    <path d="M306 190 L384 190" fill="none" stroke="#475569" stroke-width="2"/>
+    <polygon points="384,190 376,186 376,194" fill="#475569"/>
+    <path d="M456 190 L534 190" fill="none" stroke="#475569" stroke-width="2"/>
+    <polygon points="534,190 526,186 526,194" fill="#475569"/>
+    <path d="M606 190 L684 190" fill="none" stroke="#475569" stroke-width="2"/>
+    <polygon points="684,190 676,186 676,194" fill="#475569"/>
+  </g>
+
+  <!-- Critical: cycles back to Aims -->
+  <g>
+    <path d="M570 154 C 570 70, 270 70, 270 154" fill="none" stroke="#DC2626" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+    <polygon points="270,154 280,144 260,144" fill="#DC2626"/>
+    <rect x="356" y="58" width="170" height="20" rx="5" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.2"/>
+    <text x="441" y="72" font-family="sans-serif" font-size="11" fill="#991B1B" font-weight="bold" text-anchor="middle">critical: revise the Aims</text>
+  </g>
+
+  <!-- Major: cycles back to Strategy -->
+  <g>
+    <path d="M570 226 C 570 286, 420 286, 420 226" fill="none" stroke="#B45309" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+    <polygon points="420,226 430,236 410,236" fill="#B45309"/>
+    <rect x="436" y="278" width="190" height="20" rx="5" fill="#FEF3C7" stroke="#B45309" stroke-width="1.2"/>
+    <text x="531" y="292" font-family="sans-serif" font-size="11" fill="#7C2D12" font-weight="bold" text-anchor="middle">major: tighten the Approach</text>
+  </g>
+
+  <!-- Minor: in-place edit -->
+  <g>
+    <rect x="780" y="160" width="160" height="60" rx="6" fill="#ECFDF5" stroke="#059669" stroke-width="1.4"/>
+    <text x="860" y="180" font-family="sans-serif" font-size="11" fill="#065F46" font-weight="bold" text-anchor="middle">minor</text>
+    <text x="860" y="196" font-family="sans-serif" font-size="11" fill="#065F46" text-anchor="middle">edit in place,</text>
+    <text x="860" y="210" font-family="sans-serif" font-size="11" fill="#065F46" text-anchor="middle">no cycle needed</text>
+  </g>
+
+  <text x="480" y="324" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Severity tags the entry point: critical findings cycle to Aims, major to Strategy, minor stays in-place.</text>
+</svg>

--- a/docs/assets/diagrams/grant-pipeline.svg
+++ b/docs/assets/diagrams/grant-pipeline.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" width="960" height="320">
+  <!-- Title -->
+  <text x="480" y="22" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">Grant proposal = 5-stage managed pipeline</text>
+
+  <!-- Boomerang from Self-review (stage 4) back to Aims (stage 2). -->
+  <!-- Both circles: centre y=180, r=46. Anchor on each circle's upper-shoulder. -->
+  <!-- Start: upper-left of Self-review (x=580, y=148). End: upper-right of Aims (x=302, y=148). -->
+  <path d="M580 148 C 580 30, 302 30, 302 148" fill="none" stroke="#B45309" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+  <!-- Arrowhead at (302,148) pointing straight down into Aims circle (tangent at endpoint is vertical). -->
+  <polygon points="302,158 296,144 308,144" fill="#B45309"/>
+  <rect x="341" y="38" width="200" height="20" rx="5" fill="#FEF3C7" stroke="#B45309" stroke-width="1.2"/>
+  <text x="441" y="52" font-family="sans-serif" font-size="11" fill="#78350F" font-style="italic" text-anchor="middle">boomerang on review findings</text>
+
+  <!-- Stage 1: NOFO -->
+  <g>
+    <circle cx="100" cy="180" r="46" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.8"/>
+    <!-- document icon -->
+    <rect x="86" y="158" width="22" height="28" rx="2" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.6"/>
+    <line x1="90" y1="166" x2="104" y2="166" stroke="#2563EB" stroke-width="1.2"/>
+    <line x1="90" y1="172" x2="104" y2="172" stroke="#2563EB" stroke-width="1.2"/>
+    <line x1="90" y1="178" x2="100" y2="178" stroke="#2563EB" stroke-width="1.2"/>
+    <circle cx="108" cy="158" r="5" fill="#2563EB"/>
+    <text x="108" y="161" font-family="sans-serif" font-size="6" fill="#FFFFFF" font-weight="bold" text-anchor="middle">!</text>
+    <text x="100" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">1. NOFO</text>
+    <text x="100" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">read the contract</text>
+  </g>
+
+  <path d="M150 180 L210 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="210,180 202,176 202,184" fill="#475569"/>
+
+  <!-- Stage 2: Specific Aims -->
+  <g>
+    <circle cx="270" cy="180" r="46" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.8"/>
+    <!-- 1 page with aim list -->
+    <rect x="256" y="158" width="22" height="28" rx="2" fill="#FFFFFF" stroke="#B45309" stroke-width="1.6"/>
+    <line x1="260" y1="166" x2="274" y2="166" stroke="#B45309" stroke-width="1.6"/>
+    <line x1="260" y1="172" x2="272" y2="172" stroke="#B45309" stroke-width="1.2"/>
+    <line x1="260" y1="178" x2="270" y2="178" stroke="#B45309" stroke-width="1.2"/>
+    <text x="270" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">2. Aims</text>
+    <text x="270" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">1 page, 3 aims</text>
+  </g>
+
+  <path d="M320 180 L380 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="380,180 372,176 372,184" fill="#475569"/>
+
+  <!-- Stage 3: Strategy -->
+  <g>
+    <circle cx="440" cy="180" r="46" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.8"/>
+    <!-- three-column icon: significance | innovation | approach -->
+    <rect x="424" y="166" width="9" height="22" rx="1.5" fill="#7C3AED" opacity="0.55"/>
+    <rect x="435" y="160" width="9" height="28" rx="1.5" fill="#7C3AED" opacity="0.8"/>
+    <rect x="446" y="156" width="9" height="32" rx="1.5" fill="#7C3AED"/>
+    <text x="440" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">3. Strategy</text>
+    <text x="440" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">sig + innov + appr</text>
+  </g>
+
+  <path d="M490 180 L550 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="550,180 542,176 542,184" fill="#475569"/>
+
+  <!-- Stage 4: Self-review -->
+  <g>
+    <circle cx="610" cy="180" r="46" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.8"/>
+    <!-- score ribbon -->
+    <rect x="594" y="160" width="32" height="22" rx="3" fill="#FFFFFF" stroke="#DC2626" stroke-width="1.6"/>
+    <text x="610" y="176" font-family="sans-serif" font-size="11" fill="#DC2626" font-weight="bold" text-anchor="middle">1-9</text>
+    <polygon points="600,182 600,192 606,188 612,192 610,182" fill="#DC2626"/>
+    <polygon points="616,182 614,192 620,188 626,192 626,182" fill="#DC2626"/>
+    <text x="610" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">4. Self-review</text>
+    <text x="610" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">study-section sim</text>
+  </g>
+
+  <path d="M660 180 L720 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="720,180 712,176 712,184" fill="#475569"/>
+
+  <!-- Stage 5: Figure QA -->
+  <g>
+    <circle cx="780" cy="180" r="46" fill="#D1FAE5" stroke="#059669" stroke-width="1.8"/>
+    <!-- chart with checkmark -->
+    <rect x="762" y="160" width="36" height="24" rx="2" fill="#FFFFFF" stroke="#059669" stroke-width="1.6"/>
+    <rect x="766" y="174" width="4" height="8" fill="#059669"/>
+    <rect x="773" y="168" width="4" height="14" fill="#059669"/>
+    <rect x="780" y="171" width="4" height="11" fill="#059669"/>
+    <path d="M788 168 L791 172 L796 165" fill="none" stroke="#059669" stroke-width="2" stroke-linecap="round"/>
+    <text x="780" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">5. Figure QA</text>
+    <text x="780" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">res, fonts, CB-safe</text>
+  </g>
+
+  <!-- Caption -->
+  <text x="480" y="306" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Order is enforced; a self-review that cycles back is the rigor signal, not a setback.</text>
+</svg>

--- a/docs/assets/diagrams/hedit-pipeline.svg
+++ b/docs/assets/diagrams/hedit-pipeline.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <defs>
+    <marker id="arrowfwd" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+    <marker id="arrowback" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#DC2626"/>
+    </marker>
+  </defs>
+
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">HEDit -- describe in English, get validated HED</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Today: natural language -&gt; validated HED (LangGraph multi-agent)</text>
+
+  <!-- Stage 1: Parser (blue) -->
+  <g>
+    <rect x="40" y="90" width="280" height="120" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.6"/>
+    <text x="180" y="116" font-family="sans-serif" font-size="13" fill="#1E40AF" font-weight="bold" text-anchor="middle">Parser</text>
+    <text x="180" y="140" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">natural language -&gt; structured facts:</text>
+    <text x="180" y="158" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">action, body-part, direction,</text>
+    <text x="180" y="176" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">magnitude, unit</text>
+  </g>
+
+  <!-- Stage 2: Tagger (green) -->
+  <g>
+    <rect x="360" y="90" width="280" height="120" rx="6" fill="#D1FAE5" stroke="#059669" stroke-width="1.6"/>
+    <text x="500" y="116" font-family="sans-serif" font-size="13" fill="#065F46" font-weight="bold" text-anchor="middle">Tagger</text>
+    <text x="500" y="140" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">retrieve HED nodes</text>
+    <text x="500" y="158" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">(RAG over schema),</text>
+    <text x="500" y="176" font-family="sans-serif" font-size="10" fill="#065F46" text-anchor="middle">compose the tag string</text>
+  </g>
+
+  <!-- Stage 3: Validator (amber) -->
+  <g>
+    <rect x="680" y="90" width="280" height="120" rx="6" fill="#FEF3C7" stroke="#D97706" stroke-width="1.8"/>
+    <text x="820" y="116" font-family="sans-serif" font-size="13" fill="#92400E" font-weight="bold" text-anchor="middle">Validator</text>
+    <text x="820" y="140" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">official HED validator:</text>
+    <text x="820" y="158" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">tag exists? units valid?</text>
+    <text x="820" y="176" font-family="sans-serif" font-size="10" fill="#92400E" text-anchor="middle">value slot well-formed?</text>
+  </g>
+
+  <!-- Forward arrows -->
+  <line x1="320" y1="150" x2="358" y2="150" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+  <line x1="640" y1="150" x2="678" y2="150" stroke="#475569" stroke-width="1.6" marker-end="url(#arrowfwd)"/>
+
+  <!-- Red dashed feedback loop: Validator back to Tagger -->
+  <path d="M 820 210 C 820 270, 500 280, 500 212" fill="none" stroke="#DC2626" stroke-width="1.8" stroke-dasharray="6,3" marker-end="url(#arrowback)"/>
+  <text x="660" y="272" font-family="sans-serif" font-size="11" fill="#DC2626" font-weight="bold" text-anchor="middle">re-tag with validator feedback</text>
+
+  <!-- Bottom moral strip -->
+  <rect x="40" y="328" width="920" height="22" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.8"/>
+  <text x="500" y="343" font-family="sans-serif" font-size="11" fill="#1E293B" text-anchor="middle">The HED schema is the contract -- no agent invents vocabulary.</text>
+</svg>

--- a/docs/assets/diagrams/lit-review-pipeline.svg
+++ b/docs/assets/diagrams/lit-review-pipeline.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" width="960" height="320">
+  <!-- Title -->
+  <text x="480" y="22" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">Literature review = 5-stage managed pipeline</text>
+
+  <!-- Boomerang arc from Stage 5 looping back over the top and landing on the Direction box -->
+  <!-- Endpoint tangent is straight down so the arrowhead clearly points into the Direction circle -->
+  <path d="M820 140 C 820 30, 100 30, 100 134" fill="none" stroke="#B45309" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+  <polygon points="100,134 95,124 105,124" fill="#B45309"/>
+  <rect x="430" y="38" width="170" height="20" rx="5" fill="#FEF3C7" stroke="#B45309" stroke-width="1.2"/>
+  <text x="515" y="52" font-family="sans-serif" font-size="11" fill="#78350F" font-style="italic" text-anchor="middle">boomerang on gaps</text>
+
+  <!-- Stage 1: Direction -->
+  <g>
+    <circle cx="100" cy="180" r="46" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.8"/>
+    <!-- epic-tree icon: root + branches -->
+    <circle cx="100" cy="160" r="6" fill="#2563EB"/>
+    <line x1="100" y1="166" x2="84" y2="186" stroke="#2563EB" stroke-width="1.6"/>
+    <line x1="100" y1="166" x2="100" y2="190" stroke="#2563EB" stroke-width="1.6"/>
+    <line x1="100" y1="166" x2="116" y2="186" stroke="#2563EB" stroke-width="1.6"/>
+    <circle cx="84" cy="190" r="4" fill="#2563EB"/>
+    <circle cx="100" cy="194" r="4" fill="#2563EB"/>
+    <circle cx="116" cy="190" r="4" fill="#2563EB"/>
+    <text x="100" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">1. Direction</text>
+    <text x="100" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">epic + strands</text>
+  </g>
+
+  <!-- arrow 1->2 -->
+  <path d="M150 180 L210 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="210,180 202,176 202,184" fill="#475569"/>
+
+  <!-- Stage 2: Collect -->
+  <g>
+    <circle cx="270" cy="180" r="46" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.8"/>
+    <!-- search funnel icon -->
+    <circle cx="262" cy="170" r="9" fill="none" stroke="#B45309" stroke-width="2"/>
+    <line x1="269" y1="177" x2="278" y2="186" stroke="#B45309" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M254 196 L286 196 L278 206 L262 206 Z" fill="none" stroke="#B45309" stroke-width="1.6"/>
+    <text x="270" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">2. Collect</text>
+    <text x="270" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">opencite + cards</text>
+  </g>
+
+  <!-- arrow 2->3 -->
+  <path d="M320 180 L380 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="380,180 372,176 372,184" fill="#475569"/>
+
+  <!-- Stage 3: Synthesize -->
+  <g>
+    <circle cx="440" cy="180" r="46" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.8"/>
+    <!-- taxonomy tree icon -->
+    <rect x="432" y="156" width="16" height="10" rx="2" fill="none" stroke="#7C3AED" stroke-width="1.6"/>
+    <line x1="440" y1="166" x2="440" y2="176" stroke="#7C3AED" stroke-width="1.6"/>
+    <line x1="422" y1="176" x2="458" y2="176" stroke="#7C3AED" stroke-width="1.6"/>
+    <line x1="422" y1="176" x2="422" y2="184" stroke="#7C3AED" stroke-width="1.6"/>
+    <line x1="440" y1="176" x2="440" y2="184" stroke="#7C3AED" stroke-width="1.6"/>
+    <line x1="458" y1="176" x2="458" y2="184" stroke="#7C3AED" stroke-width="1.6"/>
+    <rect x="416" y="184" width="12" height="8" rx="2" fill="none" stroke="#7C3AED" stroke-width="1.6"/>
+    <rect x="434" y="184" width="12" height="8" rx="2" fill="none" stroke="#7C3AED" stroke-width="1.6"/>
+    <rect x="452" y="184" width="12" height="8" rx="2" fill="none" stroke="#7C3AED" stroke-width="1.6"/>
+    <text x="440" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">3. Synthesize</text>
+    <text x="440" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">structure first</text>
+  </g>
+
+  <!-- arrow 3->4 -->
+  <path d="M490 180 L550 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="550,180 542,176 542,184" fill="#475569"/>
+
+  <!-- Stage 4: Draft -->
+  <g>
+    <circle cx="610" cy="180" r="46" fill="#D1FAE5" stroke="#059669" stroke-width="1.8"/>
+    <!-- document with quill -->
+    <rect x="596" y="156" width="22" height="28" rx="2" fill="#FFFFFF" stroke="#059669" stroke-width="1.6"/>
+    <line x1="600" y1="164" x2="614" y2="164" stroke="#059669" stroke-width="1.2"/>
+    <line x1="600" y1="170" x2="614" y2="170" stroke="#059669" stroke-width="1.2"/>
+    <line x1="600" y1="176" x2="610" y2="176" stroke="#059669" stroke-width="1.2"/>
+    <path d="M620 158 L632 174 L626 178 Z" fill="#059669"/>
+    <line x1="619" y1="176" x2="624" y2="180" stroke="#059669" stroke-width="1.6"/>
+    <text x="610" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">4. Draft</text>
+    <text x="610" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">cite-the-card</text>
+  </g>
+
+  <!-- arrow 4->5 -->
+  <path d="M660 180 L720 180" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="720,180 712,176 712,184" fill="#475569"/>
+
+  <!-- Stage 5: Review -->
+  <g>
+    <circle cx="780" cy="180" r="46" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.8"/>
+    <!-- magnifier icon -->
+    <circle cx="774" cy="174" r="11" fill="none" stroke="#DC2626" stroke-width="2.2"/>
+    <line x1="782" y1="182" x2="794" y2="194" stroke="#DC2626" stroke-width="2.6" stroke-linecap="round"/>
+    <text x="780" y="252" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">5. Review</text>
+    <text x="780" y="270" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">findings cycle</text>
+  </g>
+
+  <!-- Caption -->
+  <text x="480" y="306" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Each stage is a check; the boomerang sends gaps back to collection, not just to the prose.</text>
+</svg>

--- a/docs/assets/diagrams/manuscript-boomerang.svg
+++ b/docs/assets/diagrams/manuscript-boomerang.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 340" width="960" height="340">
+  <text x="480" y="26" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">/manuscript:paper-review and the boomerang</text>
+  <text x="480" y="44" font-family="sans-serif" font-size="11.5" fill="#64748B" font-style="italic" text-anchor="middle">Severity-tagged findings cycle back into the right earlier stage</text>
+
+  <!-- Stages along the bottom (mini hero) -->
+  <g>
+    <circle cx="120" cy="220" r="36" fill="#FEF3C7" stroke="#B45309" stroke-width="1.6"/>
+    <text x="120" y="226" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">1. Lit</text>
+    <text x="120" y="266" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">corpus gap</text>
+  </g>
+  <path d="M156 220 L204 220" fill="none" stroke="#475569" stroke-width="1.6"/>
+  <polygon points="204,220 196,216 196,224" fill="#475569"/>
+  <g>
+    <circle cx="240" cy="220" r="36" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.6"/>
+    <text x="240" y="226" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">2. Draft</text>
+    <text x="240" y="266" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">unsupported claim</text>
+  </g>
+  <path d="M276 220 L324 220" fill="none" stroke="#475569" stroke-width="1.6"/>
+  <polygon points="324,220 316,216 316,224" fill="#475569"/>
+  <g>
+    <circle cx="360" cy="220" r="36" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.6"/>
+    <text x="360" y="226" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">3. Figures</text>
+    <text x="360" y="266" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">mismatch</text>
+  </g>
+  <path d="M396 220 L444 220" fill="none" stroke="#475569" stroke-width="1.6"/>
+  <polygon points="444,220 436,216 436,224" fill="#475569"/>
+  <g>
+    <circle cx="480" cy="220" r="36" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.8"/>
+    <text x="480" y="220" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">4. Self-</text>
+    <text x="480" y="234" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">review</text>
+    <text x="480" y="266" font-family="monospace" font-size="9.5" fill="#475569" text-anchor="middle">paper-review</text>
+  </g>
+
+  <!-- Boomerang curves from stage 4 back to stages 1, 2, 3.
+       Endpoint tangent (last control 230,110 to endpoint 120,184) is (-110, 74),
+       so the arrowhead base sits to the upper-right of the apex along that tangent. -->
+  <path d="M460 184 C 360 110, 230 110, 120 184" fill="none" stroke="#DC2626" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+  <polygon points="120,184 132.8,181.5 127.2,173.2" fill="#DC2626"/>
+
+  <!-- RIGHT: findings table -->
+  <g>
+    <rect x="540" y="64" width="380" height="244" rx="6" fill="#FFFFFF" stroke="#DC2626" stroke-width="1.4"/>
+    <rect x="540" y="64" width="380" height="26" rx="6" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.4"/>
+    <text x="730" y="82" font-family="sans-serif" font-size="11.5" fill="#991B1B" font-weight="bold" text-anchor="middle">/manuscript:paper-review  --  findings</text>
+
+    <!-- Critical -->
+    <rect x="556" y="104" width="68" height="20" rx="3" fill="#DC2626"/>
+    <text x="590" y="118" font-family="sans-serif" font-size="10" fill="#FFFFFF" font-weight="bold" text-anchor="middle">CRITICAL</text>
+    <text x="636" y="118" font-family="sans-serif" font-size="10" fill="#1E293B">"Action" claim has no card support.</text>
+    <text x="636" y="132" font-family="monospace" font-size="9.5" fill="#B45309">-&gt; Stage 1 (collect)  or  Stage 2 (drop the claim)</text>
+
+    <!-- Major -->
+    <rect x="556" y="148" width="68" height="20" rx="3" fill="#F97316"/>
+    <text x="590" y="162" font-family="sans-serif" font-size="10" fill="#FFFFFF" font-weight="bold" text-anchor="middle">MAJOR</text>
+    <text x="636" y="162" font-family="sans-serif" font-size="10" fill="#1E293B">Fig 2 does not show the asserted</text>
+    <text x="636" y="174" font-family="sans-serif" font-size="10" fill="#1E293B">timescale separation in Results.</text>
+    <text x="636" y="188" font-family="monospace" font-size="9.5" fill="#7C3AED">-&gt; Stage 3 (figure source)</text>
+
+    <!-- Major 2 -->
+    <rect x="556" y="200" width="68" height="20" rx="3" fill="#F97316"/>
+    <text x="590" y="214" font-family="sans-serif" font-size="10" fill="#FFFFFF" font-weight="bold" text-anchor="middle">MAJOR</text>
+    <text x="636" y="214" font-family="sans-serif" font-size="10" fill="#1E293B">Results re-state without bounding;</text>
+    <text x="636" y="226" font-family="sans-serif" font-size="10" fill="#1E293B">no limitations paragraph.</text>
+    <text x="636" y="240" font-family="monospace" font-size="9.5" fill="#2563EB">-&gt; Stage 2 (Discussion)</text>
+
+    <!-- Minor -->
+    <rect x="556" y="252" width="68" height="20" rx="3" fill="#94A3B8"/>
+    <text x="590" y="266" font-family="sans-serif" font-size="10" fill="#FFFFFF" font-weight="bold" text-anchor="middle">MINOR</text>
+    <text x="636" y="266" font-family="sans-serif" font-size="10" fill="#1E293B">Three em-dashes survived the humanizer.</text>
+    <text x="636" y="280" font-family="monospace" font-size="9.5" fill="#64748B">-&gt; in place (prose edit)</text>
+
+    <text x="730" y="298" font-family="sans-serif" font-size="9.5" fill="#475569" font-style="italic" text-anchor="middle">Convergence in one shot is a red flag.</text>
+  </g>
+
+  <!-- caption -->
+  <text x="280" y="326" font-family="sans-serif" font-size="10.5" fill="#64748B" font-style="italic" text-anchor="middle">Critical -&gt; cycle. Major -&gt; revise. Minor -&gt; in place.</text>
+</svg>

--- a/docs/assets/diagrams/manuscript-pipeline.svg
+++ b/docs/assets/diagrams/manuscript-pipeline.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 318" width="960" height="318">
+  <!-- Title -->
+  <text x="480" y="24" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">Manuscript = 5-stage managed pipeline (GitHub-native, then Overleaf)</text>
+
+  <!-- Vertical divider between Stage 4 and Stage 5, with band labels -->
+  <line x1="700" y1="60" x2="700" y2="280" stroke="#0D9488" stroke-width="1.4" stroke-dasharray="4,4"/>
+  <text x="430" y="58" font-family="sans-serif" font-size="11.5" fill="#1E293B" font-weight="bold" text-anchor="middle" font-style="italic">agent loop  ( GitHub-native )</text>
+  <text x="830" y="58" font-family="sans-serif" font-size="11.5" fill="#0F766E" font-weight="bold" text-anchor="middle" font-style="italic">human loop  ( Overleaf )</text>
+
+  <!-- Boomerang from Self-review (stage 4) back to Lit review (stage 1) / Draft (stage 2) / Figures (stage 3) -->
+  <path d="M610 152 C 610 70, 130 70, 130 152" fill="none" stroke="#B45309" stroke-width="2.4" stroke-dasharray="6,5" stroke-linecap="round"/>
+  <polygon points="130,162 124,148 136,148" fill="#B45309"/>
+  <rect x="280" y="78" width="200" height="20" rx="5" fill="#FEF3C7" stroke="#B45309" stroke-width="1.2"/>
+  <text x="380" y="92" font-family="sans-serif" font-size="11" fill="#78350F" font-style="italic" text-anchor="middle">boomerang on review findings</text>
+
+  <!-- Stage 1: Lit review (Amber) -->
+  <g>
+    <circle cx="130" cy="184" r="46" fill="#FEF3C7" stroke="#B45309" stroke-width="1.8"/>
+    <!-- stack of paper-cards icon -->
+    <rect x="114" y="166" width="20" height="24" rx="1.5" fill="#FFFFFF" stroke="#B45309" stroke-width="1.4"/>
+    <rect x="118" y="162" width="20" height="24" rx="1.5" fill="#FFFFFF" stroke="#B45309" stroke-width="1.4"/>
+    <rect x="122" y="158" width="20" height="24" rx="1.5" fill="#FFFFFF" stroke="#B45309" stroke-width="1.4"/>
+    <line x1="126" y1="166" x2="138" y2="166" stroke="#B45309" stroke-width="1"/>
+    <line x1="126" y1="171" x2="136" y2="171" stroke="#B45309" stroke-width="1"/>
+    <line x1="126" y1="176" x2="138" y2="176" stroke="#B45309" stroke-width="1"/>
+    <text x="130" y="256" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">1. Lit review</text>
+    <text x="130" y="274" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">paper-cards</text>
+  </g>
+
+  <path d="M180 184 L240 184" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="240,184 232,180 232,188" fill="#475569"/>
+
+  <!-- Stage 2: Draft (Blue) -->
+  <g>
+    <circle cx="300" cy="184" r="46" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.8"/>
+    <!-- IMRAD page icon: title bar + 4 section blocks -->
+    <rect x="284" y="162" width="32" height="42" rx="2" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.4"/>
+    <rect x="287" y="166" width="26" height="4" fill="#2563EB"/>
+    <rect x="287" y="174" width="26" height="5" rx="0.5" fill="#DBEAFE" stroke="#2563EB" stroke-width="0.6"/>
+    <rect x="287" y="182" width="26" height="5" rx="0.5" fill="#DBEAFE" stroke="#2563EB" stroke-width="0.6"/>
+    <rect x="287" y="190" width="26" height="5" rx="0.5" fill="#DBEAFE" stroke="#2563EB" stroke-width="0.6"/>
+    <rect x="287" y="198" width="26" height="3" rx="0.5" fill="#DBEAFE" stroke="#2563EB" stroke-width="0.6"/>
+    <text x="300" y="256" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">2. Draft</text>
+    <text x="300" y="274" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">IMRAD sections</text>
+  </g>
+
+  <path d="M350 184 L410 184" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="410,184 402,180 402,188" fill="#475569"/>
+
+  <!-- Stage 3: Figures (Purple) -->
+  <g>
+    <circle cx="470" cy="184" r="46" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.8"/>
+    <!-- two-panel figure icon: bar chart + brain blob -->
+    <rect x="450" y="166" width="40" height="30" rx="1.5" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.4"/>
+    <line x1="450" y1="181" x2="490" y2="181" stroke="#7C3AED" stroke-width="0.5"/>
+    <!-- left panel: bars -->
+    <rect x="454" y="184" width="3" height="10" fill="#7C3AED"/>
+    <rect x="459" y="178" width="3" height="16" fill="#7C3AED"/>
+    <rect x="464" y="182" width="3" height="12" fill="#7C3AED"/>
+    <!-- right panel: schematic shape -->
+    <path d="M474 184 C 474 178, 482 176, 484 182 C 488 180, 488 192, 480 192 C 476 195, 472 190, 474 184 Z" fill="#C4B5FD" stroke="#7C3AED" stroke-width="0.8"/>
+    <text x="470" y="256" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">3. Figures</text>
+    <text x="470" y="274" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">source in repo</text>
+  </g>
+
+  <path d="M520 184 L580 184" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="580,184 572,180 572,188" fill="#475569"/>
+
+  <!-- Stage 4: Self-review (Red) -->
+  <g>
+    <circle cx="640" cy="184" r="46" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.8"/>
+    <!-- magnifier over page -->
+    <rect x="624" y="166" width="22" height="28" rx="2" fill="#FFFFFF" stroke="#DC2626" stroke-width="1.4"/>
+    <line x1="628" y1="172" x2="642" y2="172" stroke="#DC2626" stroke-width="0.8"/>
+    <line x1="628" y1="178" x2="642" y2="178" stroke="#DC2626" stroke-width="0.8"/>
+    <line x1="628" y1="184" x2="638" y2="184" stroke="#DC2626" stroke-width="0.8"/>
+    <circle cx="652" cy="196" r="6" fill="none" stroke="#DC2626" stroke-width="1.8"/>
+    <line x1="656" y1="200" x2="662" y2="206" stroke="#DC2626" stroke-width="2" stroke-linecap="round"/>
+    <text x="640" y="256" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">4. Self-review</text>
+    <text x="640" y="274" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">paper-review</text>
+  </g>
+
+  <path d="M690 184 L750 184" fill="none" stroke="#475569" stroke-width="2"/>
+  <polygon points="750,184 742,180 742,188" fill="#475569"/>
+
+  <!-- Stage 5: Format & Submit (Green/Teal) -->
+  <g>
+    <circle cx="810" cy="184" r="46" fill="#D1FAE5" stroke="#059669" stroke-width="1.8"/>
+    <!-- zip/folder icon -->
+    <rect x="792" y="168" width="36" height="28" rx="2" fill="#FFFFFF" stroke="#059669" stroke-width="1.4"/>
+    <path d="M792 168 L800 168 L803 172 L828 172 L828 196 L792 196 Z" fill="#FFFFFF" stroke="#059669" stroke-width="1.4"/>
+    <rect x="808" y="175" width="4" height="3" fill="#059669"/>
+    <rect x="808" y="180" width="4" height="3" fill="#059669"/>
+    <rect x="808" y="185" width="4" height="3" fill="#059669"/>
+    <rect x="808" y="190" width="4" height="3" fill="#059669"/>
+    <text x="810" y="256" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">5. Format &amp; submit</text>
+    <text x="810" y="274" font-family="monospace" font-size="10" fill="#475569" text-anchor="middle">zip + Overleaf</text>
+  </g>
+
+  <!-- Bottom band labels (loop callouts) -->
+  <rect x="60" y="284" width="620" height="30" rx="6" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="370" y="299" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold" text-anchor="middle">Stages 1-4: agent + author co-write in the repo</text>
+  <text x="370" y="310" font-family="sans-serif" font-size="9.5" fill="#475569" text-anchor="middle" font-style="italic">epic + sub-issues + worktrees + /review-pr + /manuscript:* + /figures:*</text>
+
+  <rect x="720" y="284" width="220" height="30" rx="6" fill="#CCFBF1" stroke="#0D9488" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="830" y="299" font-family="sans-serif" font-size="11" fill="#134E4A" font-weight="bold" text-anchor="middle">Stage 5: co-authors review</text>
+  <text x="830" y="310" font-family="sans-serif" font-size="9.5" fill="#0F766E" text-anchor="middle" font-style="italic">zip -&gt; Overleaf -&gt; git clone back</text>
+</svg>

--- a/docs/assets/diagrams/mcp-wire.svg
+++ b/docs/assets/diagrams/mcp-wire.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="26" font-family="sans-serif" font-size="16" fill="#1E293B" font-weight="bold" text-anchor="middle">Skill vs MCP -- knowledge vs a wire</text>
+  <text x="500" y="46" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">a skill teaches Claude with tools it has; an MCP server gives it new tools by wiring to the outside</text>
+
+  <defs>
+    <marker id="arrow-red-mcp" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5.5" markerHeight="5.5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#DC2626"/>
+    </marker>
+  </defs>
+
+  <!-- Claude -->
+  <rect x="60" y="150" width="150" height="70" rx="8" fill="#1E293B"/>
+  <text x="135" y="182" font-family="sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF" text-anchor="middle">Claude</text>
+  <text x="135" y="201" font-family="sans-serif" font-size="9.5" fill="#CBD5E1" text-anchor="middle">the agent</text>
+
+  <!-- wire to MCP -->
+  <line x1="210" y1="185" x2="358" y2="185" stroke="#94A3B8" stroke-width="2"/>
+
+  <!-- MCP server -->
+  <rect x="360" y="143" width="180" height="84" rx="8" fill="#FEE2E2" stroke="#DC2626" stroke-width="2"/>
+  <text x="450" y="172" font-family="sans-serif" font-size="14" font-weight="bold" fill="#991B1B" text-anchor="middle">MCP server</text>
+  <text x="450" y="190" font-family="sans-serif" font-size="9.5" fill="#991B1B" text-anchor="middle">Model Context Protocol</text>
+  <text x="450" y="210" font-family="sans-serif" font-size="9.5" fill="#991B1B" text-anchor="middle">a socket to external systems</text>
+
+  <!-- wires from MCP to systems -->
+  <line x1="540" y1="185" x2="648" y2="95"  stroke="#DC2626" stroke-width="1.8" marker-end="url(#arrow-red-mcp)"/>
+  <line x1="540" y1="185" x2="648" y2="150" stroke="#DC2626" stroke-width="1.8" marker-end="url(#arrow-red-mcp)"/>
+  <line x1="540" y1="185" x2="648" y2="205" stroke="#DC2626" stroke-width="1.8" marker-end="url(#arrow-red-mcp)"/>
+  <line x1="540" y1="185" x2="648" y2="260" stroke="#DC2626" stroke-width="1.8" marker-end="url(#arrow-red-mcp)"/>
+
+  <!-- external systems -->
+  <rect x="652" y="72" width="288" height="46" rx="6" fill="#FEF9C3" stroke="#DC2626" stroke-width="2"/>
+  <text x="796" y="91" font-family="sans-serif" font-size="12.5" font-weight="bold" fill="#1E293B" text-anchor="middle">MATLAB + EEGLAB</text>
+  <text x="796" y="108" font-family="monospace" font-size="9.5" fill="#991B1B" text-anchor="middle">matlab-mcp -- you drove this all course</text>
+
+  <rect x="652" y="128" width="288" height="42" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="796" y="154" font-family="sans-serif" font-size="12" fill="#475569" text-anchor="middle">A database</text>
+
+  <rect x="652" y="184" width="288" height="42" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="796" y="210" font-family="sans-serif" font-size="12" fill="#475569" text-anchor="middle">A web API</text>
+
+  <rect x="652" y="240" width="288" height="42" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="796" y="266" font-family="sans-serif" font-size="12" fill="#475569" text-anchor="middle">A browser</text>
+
+  <!-- bottom strip -->
+  <rect x="60" y="320" width="880" height="24" rx="5" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="336" font-family="sans-serif" font-size="11" fill="#1E293B" text-anchor="middle" font-weight="bold">If the job needs the outside world, it is an MCP server, not a skill.</text>
+</svg>

--- a/docs/assets/diagrams/neuro-plugin-map.svg
+++ b/docs/assets/diagrams/neuro-plugin-map.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="24" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">The neuroinformatics plugin -- 2 skills + 1 agent</text>
+  <text x="500" y="42" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Conversion skill at the centre; the validator agent defends it; experiment-design waits in the wings</text>
+
+  <defs>
+    <marker id="arrow-agent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#BE185D"/>
+    </marker>
+  </defs>
+
+  <!-- Agent card (top) -->
+  <g>
+    <rect x="370" y="64" width="260" height="78" rx="6" fill="#FCE7F3" stroke="#BE185D" stroke-width="1.8"/>
+    <rect x="370" y="64" width="260" height="24" rx="6" fill="#FBCFE8" stroke="#BE185D" stroke-width="1.8"/>
+    <text x="500" y="81" font-family="monospace" font-size="11.5" fill="#831843" font-weight="bold" text-anchor="middle">bids-validator</text>
+    <text x="500" y="106" font-family="sans-serif" font-size="10.5" fill="#9D174D" font-weight="bold" text-anchor="middle">agent -- autonomous validate + fix</text>
+    <text x="500" y="123" font-family="sans-serif" font-size="10" fill="#9D174D" text-anchor="middle">this week's mechanical defence</text>
+  </g>
+
+  <!-- Arrow from agent down to center card -->
+  <line x1="500" y1="142" x2="500" y2="186" stroke="#BE185D" stroke-width="1.6" marker-end="url(#arrow-agent)"/>
+
+  <!-- Center card (blue, emphasized) -->
+  <g>
+    <rect x="350" y="188" width="300" height="96" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="2"/>
+    <rect x="350" y="188" width="300" height="26" rx="6" fill="#BFDBFE" stroke="#2563EB" stroke-width="2"/>
+    <text x="500" y="206" font-family="monospace" font-size="11.5" fill="#1E40AF" font-weight="bold" text-anchor="middle">/neuroinformatics:bids-conversion</text>
+    <text x="500" y="234" font-family="sans-serif" font-size="12.5" fill="#1E40AF" font-weight="bold" text-anchor="middle">Guided BIDS conversion</text>
+    <text x="500" y="253" font-family="sans-serif" font-size="10.5" fill="#1E40AF" text-anchor="middle">EEG, EMG, MEG, fMRI</text>
+    <text x="500" y="271" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">today's focus</text>
+  </g>
+
+  <!-- Dimmed/secondary card (experiment-design) -->
+  <g opacity="0.55">
+    <rect x="700" y="200" width="248" height="84" rx="6" fill="#F1F5F9" stroke="#94A3B8" stroke-width="1.4"/>
+    <text x="824" y="220" font-family="monospace" font-size="10" fill="#475569" font-weight="bold" text-anchor="middle">/neuroinformatics:experiment-design</text>
+    <text x="824" y="240" font-family="sans-serif" font-size="10.5" fill="#475569" font-weight="bold" text-anchor="middle">PsychoPy + Lab Streaming Layer</text>
+    <text x="824" y="256" font-family="sans-serif" font-size="9.5" fill="#64748B" text-anchor="middle">data collection</text>
+    <text x="824" y="273" font-family="sans-serif" font-size="9.5" fill="#64748B" font-style="italic" text-anchor="middle">(in the plugin; not today's focus)</text>
+  </g>
+
+  <!-- Bottom moral strip -->
+  <rect x="60" y="318" width="880" height="22" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="333" font-family="sans-serif" font-size="10.5" fill="#1E293B" text-anchor="middle">HED annotation lives inside the skills; today's focus is conversion + validation.</text>
+</svg>

--- a/docs/assets/diagrams/nih-scoring.svg
+++ b/docs/assets/diagrams/nih-scoring.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 360" width="960" height="360">
+  <text x="480" y="26" font-family="sans-serif" font-size="15" fill="#1E293B" font-weight="bold" text-anchor="middle">NIH study section: 5 criteria, 1-9 scoring, integrated impact score</text>
+
+  <!-- Five criteria icons across the top -->
+  <g>
+    <!-- Significance -->
+    <rect x="40" y="60" width="170" height="92" rx="8" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.6"/>
+    <circle cx="78" cy="106" r="20" fill="#2563EB"/>
+    <text x="78" y="111" font-family="sans-serif" font-size="18" fill="#FFFFFF" font-weight="bold" text-anchor="middle">S</text>
+    <text x="125" y="92" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Significance</text>
+    <text x="125" y="111" font-family="sans-serif" font-size="11" fill="#475569">Why does</text>
+    <text x="125" y="126" font-family="sans-serif" font-size="11" fill="#475569">the field need</text>
+    <text x="125" y="141" font-family="sans-serif" font-size="11" fill="#475569">this answered?</text>
+  </g>
+  <g>
+    <rect x="225" y="60" width="170" height="92" rx="8" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.6"/>
+    <circle cx="263" cy="106" r="20" fill="#7C3AED"/>
+    <text x="263" y="111" font-family="sans-serif" font-size="18" fill="#FFFFFF" font-weight="bold" text-anchor="middle">In</text>
+    <text x="310" y="92" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Investigator</text>
+    <text x="310" y="111" font-family="sans-serif" font-size="11" fill="#475569">Right team</text>
+    <text x="310" y="126" font-family="sans-serif" font-size="11" fill="#475569">at the right</text>
+    <text x="310" y="141" font-family="sans-serif" font-size="11" fill="#475569">career stage?</text>
+  </g>
+  <g>
+    <rect x="410" y="60" width="170" height="92" rx="8" fill="#FEF3C7" stroke="#B45309" stroke-width="1.6"/>
+    <circle cx="448" cy="106" r="20" fill="#B45309"/>
+    <text x="448" y="111" font-family="sans-serif" font-size="18" fill="#FFFFFF" font-weight="bold" text-anchor="middle">I</text>
+    <text x="495" y="92" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Innovation</text>
+    <text x="495" y="111" font-family="sans-serif" font-size="11" fill="#475569">What is new</text>
+    <text x="495" y="126" font-family="sans-serif" font-size="11" fill="#475569">vs the field</text>
+    <text x="495" y="141" font-family="sans-serif" font-size="11" fill="#475569">today?</text>
+  </g>
+  <g>
+    <rect x="595" y="60" width="170" height="92" rx="8" fill="#D1FAE5" stroke="#059669" stroke-width="1.6"/>
+    <circle cx="633" cy="106" r="20" fill="#059669"/>
+    <text x="633" y="111" font-family="sans-serif" font-size="18" fill="#FFFFFF" font-weight="bold" text-anchor="middle">A</text>
+    <text x="680" y="92" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Approach</text>
+    <text x="680" y="111" font-family="sans-serif" font-size="11" fill="#475569">Rigorous,</text>
+    <text x="680" y="126" font-family="sans-serif" font-size="11" fill="#475569">feasible,</text>
+    <text x="680" y="141" font-family="sans-serif" font-size="11" fill="#475569">de-risked?</text>
+  </g>
+  <g>
+    <rect x="780" y="60" width="140" height="92" rx="8" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.6"/>
+    <circle cx="815" cy="106" r="20" fill="#DC2626"/>
+    <text x="815" y="111" font-family="sans-serif" font-size="18" fill="#FFFFFF" font-weight="bold" text-anchor="middle">E</text>
+    <text x="855" y="92" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Environment</text>
+    <text x="855" y="111" font-family="sans-serif" font-size="11" fill="#475569">Institution</text>
+    <text x="855" y="126" font-family="sans-serif" font-size="11" fill="#475569">enables the</text>
+    <text x="855" y="141" font-family="sans-serif" font-size="11" fill="#475569">work?</text>
+  </g>
+
+  <!-- Scoring ladder -->
+  <text x="40" y="190" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold">Scoring (per criterion + integrated impact)</text>
+
+  <!-- Gradient bar -->
+  <defs>
+    <linearGradient id="scoreGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="22%" stop-color="#10B981"/>
+      <stop offset="44%" stop-color="#FACC15"/>
+      <stop offset="66%" stop-color="#F59E0B"/>
+      <stop offset="88%" stop-color="#DC2626"/>
+    </linearGradient>
+  </defs>
+  <rect x="40" y="208" width="880" height="38" rx="6" fill="url(#scoreGradient)" stroke="#1E293B" stroke-width="0.8"/>
+
+  <!-- Score ticks 1-9 -->
+  <g font-family="sans-serif" font-size="12" fill="#FFFFFF" font-weight="bold" text-anchor="middle">
+    <text x="89" y="233">1</text>
+    <text x="187" y="233">2</text>
+    <text x="285" y="233">3</text>
+    <text x="383" y="233">4</text>
+    <text x="481" y="233">5</text>
+    <text x="579" y="233">6</text>
+    <text x="677" y="233">7</text>
+    <text x="775" y="233">8</text>
+    <text x="873" y="233">9</text>
+  </g>
+
+  <!-- Score-band labels -->
+  <g font-family="sans-serif" font-size="11" fill="#1E293B">
+    <text x="138" y="270" text-anchor="middle">Exceptional</text>
+    <text x="138" y="284" text-anchor="middle" fill="#475569" font-style="italic">no weaknesses</text>
+
+    <text x="334" y="270" text-anchor="middle">Excellent</text>
+    <text x="334" y="284" text-anchor="middle" fill="#475569" font-style="italic">minor weaknesses</text>
+
+    <text x="530" y="270" text-anchor="middle">Good</text>
+    <text x="530" y="284" text-anchor="middle" fill="#475569" font-style="italic">moderate weaknesses</text>
+
+    <text x="726" y="270" text-anchor="middle">Fair</text>
+    <text x="726" y="284" text-anchor="middle" fill="#475569" font-style="italic">major weaknesses</text>
+
+    <text x="873" y="270" text-anchor="middle">Poor</text>
+    <text x="873" y="284" text-anchor="middle" fill="#475569" font-style="italic">flawed</text>
+  </g>
+
+  <!-- Funding line callout -->
+  <g>
+    <line x1="40" y1="312" x2="280" y2="312" stroke="#059669" stroke-width="2.4"/>
+    <circle cx="280" cy="312" r="5" fill="#059669"/>
+    <text x="290" y="316" font-family="sans-serif" font-size="12" fill="#065F46" font-weight="bold">Fundable band</text>
+    <text x="395" y="316" font-family="sans-serif" font-size="11" fill="#475569" font-style="italic">~impact score &lt;= 30 (varies by institute, cycle)</text>
+  </g>
+
+  <text x="480" y="346" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">A 1 in any single criterion does not save a 5 in Approach; reviewers tie everything back to the impact score.</text>
+</svg>

--- a/docs/assets/diagrams/opencite-output-tree.svg
+++ b/docs/assets/diagrams/opencite-output-tree.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" width="720" height="360">
+  <!-- Title -->
+  <text x="360" y="24" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">batch-fetch --convert output tree</text>
+
+  <!-- Background panel -->
+  <rect x="40" y="46" width="640" height="290" rx="8" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1"/>
+
+  <!-- Tree structure -->
+  <!-- papers/ root -->
+  <path d="M70 78 L90 78 L94 84 L160 84 L160 102 L70 102 Z" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.4"/>
+  <text x="115" y="96" font-family="monospace" font-size="11" fill="#1E40AF" font-weight="bold" text-anchor="middle">papers/</text>
+
+  <!-- vertical line under papers -->
+  <line x1="86" y1="102" x2="86" y2="298" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="2,3"/>
+
+  <!-- pdf/ folder -->
+  <line x1="86" y1="124" x2="106" y2="124" stroke="#94A3B8" stroke-width="1.2"/>
+  <path d="M106 116 L122 116 L126 122 L184 122 L184 138 L106 138 Z" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.4"/>
+  <text x="145" y="132" font-family="monospace" font-size="11" fill="#78350F" font-weight="bold" text-anchor="middle">pdf/</text>
+
+  <!-- pdf line under -->
+  <line x1="120" y1="138" x2="120" y2="194" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="2,3"/>
+
+  <!-- paper-A.pdf [open] -->
+  <line x1="120" y1="160" x2="140" y2="160" stroke="#94A3B8" stroke-width="1.2"/>
+  <rect x="140" y="150" width="120" height="20" rx="3" fill="#FFFFFF" stroke="#475569" stroke-width="1.2"/>
+  <text x="148" y="164" font-family="monospace" font-size="10" fill="#1E293B">paper-A.pdf</text>
+  <rect x="270" y="152" width="56" height="16" rx="8" fill="#D1FAE5" stroke="#059669" stroke-width="1.2"/>
+  <text x="298" y="164" font-family="monospace" font-size="9" fill="#064E3B" font-weight="bold" text-anchor="middle">open</text>
+
+  <!-- paper-B.pdf [paywall, struck through] -->
+  <line x1="120" y1="184" x2="140" y2="184" stroke="#94A3B8" stroke-width="1.2"/>
+  <rect x="140" y="174" width="120" height="20" rx="3" fill="#FFFFFF" stroke="#475569" stroke-width="1.2"/>
+  <text x="148" y="188" font-family="monospace" font-size="10" fill="#475569" text-decoration="line-through">paper-B.pdf</text>
+  <rect x="270" y="176" width="64" height="16" rx="8" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.2"/>
+  <text x="302" y="188" font-family="monospace" font-size="9" fill="#7F1D1D" font-weight="bold" text-anchor="middle">paywall</text>
+  <line x1="272" y1="184" x2="332" y2="184" stroke="#DC2626" stroke-width="1.4"/>
+
+  <!-- markdown/ folder -->
+  <line x1="86" y1="220" x2="106" y2="220" stroke="#94A3B8" stroke-width="1.2"/>
+  <path d="M106 212 L122 212 L126 218 L208 218 L208 234 L106 234 Z" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.4"/>
+  <text x="157" y="228" font-family="monospace" font-size="11" fill="#5B21B6" font-weight="bold" text-anchor="middle">markdown/</text>
+
+  <line x1="120" y1="234" x2="120" y2="304" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="2,3"/>
+
+  <!-- paper-A.md -->
+  <line x1="120" y1="252" x2="140" y2="252" stroke="#94A3B8" stroke-width="1.2"/>
+  <rect x="140" y="244" width="120" height="18" rx="3" fill="#FFFFFF" stroke="#475569" stroke-width="1.2"/>
+  <text x="148" y="257" font-family="monospace" font-size="10" fill="#1E293B">paper-A.md</text>
+
+  <!-- paper-B.md -->
+  <line x1="120" y1="274" x2="140" y2="274" stroke="#94A3B8" stroke-width="1.2"/>
+  <rect x="140" y="266" width="120" height="18" rx="3" fill="#FFFFFF" stroke="#475569" stroke-width="1.2"/>
+  <text x="148" y="279" font-family="monospace" font-size="10" fill="#1E293B">paper-B.md</text>
+  <text x="270" y="279" font-family="sans-serif" font-size="10" fill="#059669" font-style="italic">always present</text>
+
+  <!-- img/ folder -->
+  <line x1="120" y1="296" x2="140" y2="296" stroke="#94A3B8" stroke-width="1.2"/>
+  <path d="M140 288 L156 288 L160 294 L208 294 L208 304 L140 304 Z" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.2"/>
+  <text x="174" y="301" font-family="monospace" font-size="10" fill="#5B21B6" font-weight="bold" text-anchor="middle">img/</text>
+
+  <line x1="156" y1="304" x2="156" y2="320" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="2,3"/>
+  <line x1="156" y1="318" x2="176" y2="318" stroke="#94A3B8" stroke-width="1.2"/>
+  <path d="M176 312 L192 312 L196 316 L260 316 L260 324 L176 324 Z" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.2"/>
+  <text x="218" y="321" font-family="monospace" font-size="9" fill="#5B21B6" text-anchor="middle">paper-A/</text>
+
+  <!-- Right side annotations -->
+  <rect x="380" y="94" width="280" height="60" rx="6" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.4"/>
+  <text x="392" y="112" font-family="sans-serif" font-size="11" fill="#1E40AF" font-weight="bold">Two parallel structures</text>
+  <text x="392" y="128" font-family="sans-serif" font-size="10" fill="#475569">PDFs may be blocked, but markdown</text>
+  <text x="392" y="142" font-family="sans-serif" font-size="10" fill="#475569">conversions are always available.</text>
+
+  <rect x="380" y="170" width="280" height="60" rx="6" fill="#FFFFFF" stroke="#059669" stroke-width="1.4"/>
+  <text x="392" y="188" font-family="sans-serif" font-size="11" fill="#064E3B" font-weight="bold">Open badge</text>
+  <text x="392" y="204" font-family="sans-serif" font-size="10" fill="#475569">PDF retrieved successfully and</text>
+  <text x="392" y="218" font-family="sans-serif" font-size="10" fill="#475569">stored under pdf/.</text>
+
+  <rect x="380" y="246" width="280" height="60" rx="6" fill="#FFFFFF" stroke="#DC2626" stroke-width="1.4"/>
+  <text x="392" y="264" font-family="sans-serif" font-size="11" fill="#7F1D1D" font-weight="bold">Paywall badge</text>
+  <text x="392" y="280" font-family="sans-serif" font-size="10" fill="#475569">PDF blocked; markdown still made</text>
+  <text x="392" y="294" font-family="sans-serif" font-size="10" fill="#475569">via abstract/metadata.</text>
+</svg>

--- a/docs/assets/diagrams/opencite-strategies.svg
+++ b/docs/assets/diagrams/opencite-strategies.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 320" width="760" height="320">
+  <!-- Title -->
+  <text x="380" y="24" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">opencite: three search strategies</text>
+
+  <!-- Central query node -->
+  <rect x="320" y="46" width="120" height="40" rx="20" fill="#1E293B" stroke="#0F172A" stroke-width="1.6"/>
+  <text x="380" y="71" font-family="monospace" font-size="13" fill="#FFFFFF" font-weight="bold" text-anchor="middle">query</text>
+
+  <!-- Path 1: canonical (down-left, blue) -->
+  <!-- Tangent at endpoint: (130-200, 170-130) = (-70, 40); arrowhead points down-left along that vector -->
+  <path d="M340 86 Q 200 130, 130 170" fill="none" stroke="#2563EB" stroke-width="2"/>
+  <polygon points="130,170 141,168 137,160" fill="#2563EB"/>
+  <rect x="50" y="180" width="160" height="48" rx="6" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.6"/>
+  <!-- star icon -->
+  <polygon points="80,196 84,206 95,207 87,214 89,225 80,219 71,225 73,214 65,207 76,206" fill="#2563EB"/>
+  <text x="150" y="200" font-family="sans-serif" font-size="12" fill="#1E40AF" font-weight="bold" text-anchor="middle">canonical</text>
+  <text x="150" y="216" font-family="sans-serif" font-size="10" fill="#1E40AF" text-anchor="middle">high-citation</text>
+  <!-- paper card stack -->
+  <rect x="100" y="248" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.2"/>
+  <rect x="106" y="254" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.2"/>
+  <rect x="112" y="260" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.4"/>
+  <line x1="120" y1="272" x2="164" y2="272" stroke="#2563EB" stroke-width="1.2"/>
+  <line x1="120" y1="280" x2="160" y2="280" stroke="#2563EB" stroke-width="1.2"/>
+  <line x1="120" y1="288" x2="158" y2="288" stroke="#2563EB" stroke-width="1.2"/>
+
+  <!-- Path 2: search (straight down, amber) -->
+  <line x1="380" y1="86" x2="380" y2="170" stroke="#F59E0B" stroke-width="2"/>
+  <polygon points="380,170 376,162 384,162" fill="#F59E0B"/>
+  <rect x="300" y="180" width="160" height="48" rx="6" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.6"/>
+  <!-- magnifier icon -->
+  <circle cx="324" cy="204" r="9" fill="none" stroke="#B45309" stroke-width="2"/>
+  <line x1="331" y1="211" x2="340" y2="220" stroke="#B45309" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="400" y="200" font-family="sans-serif" font-size="12" fill="#78350F" font-weight="bold" text-anchor="middle">search</text>
+  <text x="400" y="216" font-family="sans-serif" font-size="10" fill="#78350F" text-anchor="middle">recent / specific</text>
+  <rect x="350" y="248" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.2"/>
+  <rect x="356" y="254" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.2"/>
+  <rect x="362" y="260" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.4"/>
+  <line x1="370" y1="272" x2="414" y2="272" stroke="#F59E0B" stroke-width="1.2"/>
+  <line x1="370" y1="280" x2="410" y2="280" stroke="#F59E0B" stroke-width="1.2"/>
+  <line x1="370" y1="288" x2="408" y2="288" stroke="#F59E0B" stroke-width="1.2"/>
+
+  <!-- Path 3: cite (down-right, purple) -->
+  <!-- Tangent at endpoint: (630-560, 170-130) = (70, 40); arrowhead points down-right along that vector -->
+  <path d="M420 86 Q 560 130, 630 170" fill="none" stroke="#7C3AED" stroke-width="2"/>
+  <polygon points="630,170 619,168 623,160" fill="#7C3AED"/>
+  <rect x="550" y="180" width="160" height="48" rx="6" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.6"/>
+  <!-- citation graph icon: linked nodes -->
+  <circle cx="572" cy="200" r="4" fill="#7C3AED"/>
+  <circle cx="586" cy="212" r="4" fill="#7C3AED"/>
+  <circle cx="572" cy="222" r="4" fill="#7C3AED"/>
+  <circle cx="600" cy="200" r="4" fill="#7C3AED"/>
+  <line x1="572" y1="200" x2="586" y2="212" stroke="#7C3AED" stroke-width="1.4"/>
+  <line x1="586" y1="212" x2="572" y2="222" stroke="#7C3AED" stroke-width="1.4"/>
+  <line x1="586" y1="212" x2="600" y2="200" stroke="#7C3AED" stroke-width="1.4"/>
+  <text x="650" y="200" font-family="sans-serif" font-size="12" fill="#5B21B6" font-weight="bold" text-anchor="middle">cite</text>
+  <text x="650" y="216" font-family="sans-serif" font-size="10" fill="#5B21B6" text-anchor="middle">graph traversal</text>
+  <rect x="600" y="248" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.2"/>
+  <rect x="606" y="254" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.2"/>
+  <rect x="612" y="260" width="60" height="50" rx="3" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.4"/>
+  <line x1="620" y1="272" x2="664" y2="272" stroke="#7C3AED" stroke-width="1.2"/>
+  <line x1="620" y1="280" x2="660" y2="280" stroke="#7C3AED" stroke-width="1.2"/>
+  <line x1="620" y1="288" x2="658" y2="288" stroke="#7C3AED" stroke-width="1.2"/>
+</svg>

--- a/docs/assets/diagrams/paper-card-anatomy.svg
+++ b/docs/assets/diagrams/paper-card-anatomy.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 460" width="720" height="460">
+  <!-- Title -->
+  <text x="360" y="24" font-family="sans-serif" font-size="14" fill="#1E293B" font-weight="bold" text-anchor="middle">paper-card.md anatomy</text>
+
+  <!-- The card.md page (tall rectangle) -->
+  <rect x="80" y="46" width="280" height="396" rx="6" fill="#FFFFFF" stroke="#1E293B" stroke-width="1.6"/>
+
+  <!-- Front-matter block (top, monospace, muted gray) -->
+  <rect x="92" y="58" width="256" height="148" rx="4" fill="#F1F5F9" stroke="#94A3B8" stroke-width="1.2"/>
+  <text x="100" y="74" font-family="monospace" font-size="10" fill="#64748B">---</text>
+  <text x="100" y="88" font-family="monospace" font-size="10" fill="#1E293B">slug: smith-2023-shot-erp</text>
+  <text x="100" y="102" font-family="monospace" font-size="10" fill="#1E293B">type: empirical</text>
+  <text x="100" y="116" font-family="monospace" font-size="10" fill="#1E293B">year: 2023</text>
+  <text x="100" y="130" font-family="monospace" font-size="10" fill="#1E293B">doi: 10.1038/...</text>
+  <text x="100" y="144" font-family="monospace" font-size="10" fill="#1E293B">license: cc-by</text>
+  <text x="100" y="158" font-family="monospace" font-size="10" fill="#1E293B">agi_relevance: high</text>
+  <text x="100" y="172" font-family="monospace" font-size="10" fill="#1E293B">pdf_status: open</text>
+  <text x="100" y="186" font-family="monospace" font-size="10" fill="#64748B">---</text>
+
+  <!-- 6 section rows -->
+  <rect x="92" y="216" width="256" height="32" rx="4" fill="#DBEAFE" stroke="#2563EB" stroke-width="1.2"/>
+  <text x="102" y="237" font-family="sans-serif" font-size="11" fill="#1E40AF" font-weight="bold">## TL;DR</text>
+
+  <rect x="92" y="252" width="256" height="32" rx="4" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.2"/>
+  <text x="102" y="273" font-family="sans-serif" font-size="11" fill="#78350F" font-weight="bold">## Summary</text>
+
+  <rect x="92" y="288" width="256" height="32" rx="4" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.2"/>
+  <text x="102" y="309" font-family="sans-serif" font-size="11" fill="#5B21B6" font-weight="bold">## Relevance</text>
+
+  <rect x="92" y="324" width="256" height="32" rx="4" fill="#D1FAE5" stroke="#059669" stroke-width="1.2"/>
+  <text x="102" y="345" font-family="sans-serif" font-size="11" fill="#064E3B" font-weight="bold">## Notable details</text>
+
+  <rect x="92" y="360" width="256" height="32" rx="4" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.2"/>
+  <text x="102" y="381" font-family="sans-serif" font-size="11" fill="#7F1D1D" font-weight="bold">## Open questions</text>
+
+  <rect x="92" y="396" width="256" height="32" rx="4" fill="#E0E7FF" stroke="#4338CA" stroke-width="1.2"/>
+  <text x="102" y="417" font-family="sans-serif" font-size="11" fill="#3730A3" font-weight="bold">## Citations</text>
+
+  <!-- Callout: schema-enforced metadata -->
+  <line x1="348" y1="130" x2="440" y2="130" stroke="#2563EB" stroke-width="1.2" stroke-dasharray="2,2"/>
+  <rect x="440" y="98" width="240" height="64" rx="6" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.4"/>
+  <text x="452" y="118" font-family="sans-serif" font-size="12" fill="#1E40AF" font-weight="bold">schema-enforced metadata</text>
+  <text x="452" y="134" font-family="sans-serif" font-size="10" fill="#475569">YAML front matter validated by</text>
+  <text x="452" y="148" font-family="monospace" font-size="10" fill="#475569">opencite</text>
+  <text x="492" y="148" font-family="sans-serif" font-size="10" fill="#475569">; broken cards fail review.</text>
+
+  <!-- Callout: 6 required sections -->
+  <line x1="348" y1="320" x2="440" y2="320" stroke="#7C3AED" stroke-width="1.2" stroke-dasharray="2,2"/>
+  <rect x="440" y="288" width="240" height="64" rx="6" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.4"/>
+  <text x="452" y="308" font-family="sans-serif" font-size="12" fill="#5B21B6" font-weight="bold">6 required sections</text>
+  <text x="452" y="324" font-family="sans-serif" font-size="10" fill="#475569">Same shape across every card so</text>
+  <text x="452" y="338" font-family="sans-serif" font-size="10" fill="#475569">synthesis can scan them quickly.</text>
+
+  <!-- footer -->
+  <text x="360" y="450" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Every claim in the literature review must point at one of these.</text>
+</svg>

--- a/docs/assets/diagrams/plugin-ecosystem.svg
+++ b/docs/assets/diagrams/plugin-ecosystem.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- Central hub: Plugin -->
+  <rect x="65" y="10" width="70" height="28" rx="6" fill="#2563EB" stroke="#1D4ED8" stroke-width="1.5"/>
+  <text x="100" y="28" font-family="sans-serif" font-size="11" fill="white" text-anchor="middle" font-weight="bold">Plugin</text>
+  <!-- Connection lines from hub -->
+  <line x1="80" y1="38" x2="45" y2="70" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="100" y1="38" x2="100" y2="70" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="120" y1="38" x2="155" y2="70" stroke="#94A3B8" stroke-width="1.5"/>
+  <!-- MCP dashed line from plugin (drawn BEFORE cards so it goes behind Hooks) -->
+  <line x1="100" y1="38" x2="100" y2="108" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3 3"/>
+  <!-- Skills box -->
+  <rect x="15" y="70" width="60" height="24" rx="5" fill="#22C55E" opacity="0.9"/>
+  <text x="45" y="86" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle" font-weight="bold">Skills</text>
+  <!-- Hooks box (covers the dashed line behind it) -->
+  <rect x="70" y="70" width="60" height="24" rx="5" fill="#F59E0B" opacity="0.9"/>
+  <text x="100" y="86" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle" font-weight="bold">Hooks</text>
+  <!-- Agents box -->
+  <rect x="125" y="70" width="60" height="24" rx="5" fill="#A78BFA" opacity="0.9"/>
+  <text x="155" y="86" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle" font-weight="bold">Agents</text>
+  <!-- MCP box -->
+  <rect x="62" y="108" width="76" height="24" rx="5" fill="#EF4444" opacity="0.85"/>
+  <text x="100" y="124" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle" font-weight="bold">MCP Servers</text>
+  <!-- Separate section: CLAUDE.md -->
+  <line x1="30" y1="148" x2="170" y2="148" stroke="#CBD5E1" stroke-width="1" stroke-dasharray="4 4"/>
+  <text x="100" y="145" font-family="sans-serif" font-size="8" fill="#94A3B8" text-anchor="middle">always loaded</text>
+  <!-- CLAUDE.md -->
+  <rect x="20" y="158" width="75" height="24" rx="5" fill="#334155"/>
+  <text x="57" y="174" font-family="monospace" font-size="9" fill="white" text-anchor="middle">CLAUDE.md</text>
+  <!-- Auto Memory -->
+  <rect x="105" y="158" width="75" height="24" rx="5" fill="#334155"/>
+  <text x="142" y="174" font-family="monospace" font-size="9" fill="white" text-anchor="middle">Auto Memory</text>
+</svg>

--- a/docs/assets/diagrams/skill-anatomy.svg
+++ b/docs/assets/diagrams/skill-anatomy.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360">
+  <text x="500" y="26" font-family="sans-serif" font-size="16" fill="#1E293B" font-weight="bold" text-anchor="middle">Anatomy of a skill</text>
+  <text x="500" y="46" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">one required file, three optional folders -- each loaded only when needed</text>
+
+  <!-- tree panel -->
+  <rect x="60" y="74" width="420" height="240" rx="10" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="90" y="110" font-family="monospace" font-size="14" font-weight="bold" fill="#1E293B">shot-change-erp/</text>
+
+  <text x="110" y="150" font-family="monospace" font-size="13" fill="#166534" font-weight="bold">├── SKILL.md</text>
+  <text x="300" y="150" font-family="sans-serif" font-size="9.5" fill="#94A3B8">required</text>
+  <text x="135" y="168" font-family="monospace" font-size="10" fill="#64748B">frontmatter + body</text>
+
+  <text x="110" y="200" font-family="monospace" font-size="13" fill="#1E293B">├── references/</text>
+  <text x="110" y="240" font-family="monospace" font-size="13" fill="#1E293B">├── scripts/</text>
+  <text x="110" y="280" font-family="monospace" font-size="13" fill="#1E293B">└── assets/</text>
+
+  <!-- annotation cards (right), aligned to each tree line -->
+  <!-- SKILL.md -->
+  <rect x="520" y="128" width="420" height="40" rx="6" fill="#DCFCE7" stroke="#16A34A" stroke-width="1.8"/>
+  <text x="538" y="146" font-family="monospace" font-size="11.5" font-weight="bold" fill="#166534">SKILL.md</text>
+  <text x="640" y="146" font-family="sans-serif" font-size="11" fill="#166534">the entry point -- always read first when it triggers</text>
+  <text x="538" y="161" font-family="sans-serif" font-size="9.5" fill="#166534">name + description (the trigger) and the lean instructions</text>
+
+  <!-- references -->
+  <rect x="520" y="184" width="420" height="34" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="538" y="205" font-family="monospace" font-size="11.5" font-weight="bold" fill="#334155">references/</text>
+  <text x="645" y="205" font-family="sans-serif" font-size="10.5" fill="#475569">detailed docs, loaded only when needed</text>
+
+  <!-- scripts -->
+  <rect x="520" y="224" width="420" height="34" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="538" y="245" font-family="monospace" font-size="11.5" font-weight="bold" fill="#334155">scripts/</text>
+  <text x="645" y="245" font-family="sans-serif" font-size="10.5" fill="#475569">code, executed -- token-free, not always read</text>
+
+  <!-- assets -->
+  <rect x="520" y="264" width="420" height="34" rx="6" fill="#FFFFFF" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="538" y="285" font-family="monospace" font-size="11.5" font-weight="bold" fill="#334155">assets/</text>
+  <text x="645" y="285" font-family="sans-serif" font-size="10.5" fill="#475569">templates, icons, fonts used in your output</text>
+
+  <!-- bottom strip -->
+  <rect x="60" y="324" width="880" height="24" rx="5" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="340" font-family="sans-serif" font-size="11" fill="#1E293B" text-anchor="middle" font-weight="bold">A skill is knowledge, packaged so it loads only when it is relevant.</text>
+</svg>

--- a/docs/assets/diagrams/skill-vs-agent.svg
+++ b/docs/assets/diagrams/skill-vs-agent.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 390" width="1000" height="390">
+  <text x="500" y="26" font-family="sans-serif" font-size="16" fill="#1E293B" font-weight="bold" text-anchor="middle">Skill vs Agent -- the confusion worth clearing</text>
+  <text x="500" y="46" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">both are triggered by Claude; the difference is where the work happens</text>
+
+  <defs>
+    <marker id="arrow-delegate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7C3AED"/>
+    </marker>
+    <marker id="arrow-result" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#16A34A"/>
+    </marker>
+  </defs>
+
+  <!-- LEFT: skill in the main conversation -->
+  <rect x="55" y="74" width="400" height="206" rx="10" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="75" y="98" font-family="sans-serif" font-size="11" font-weight="bold" fill="#64748B">MAIN CONVERSATION</text>
+  <!-- a chat bubble holding the skill -->
+  <rect x="95" y="120" width="320" height="120" rx="10" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.2"/>
+  <rect x="120" y="150" width="270" height="62" rx="8" fill="#DCFCE7" stroke="#16A34A" stroke-width="1.8"/>
+  <rect x="120" y="150" width="270" height="22" rx="8" fill="#BBF7D0" stroke="#16A34A" stroke-width="1.8"/>
+  <text x="255" y="166" font-family="monospace" font-size="11" font-weight="bold" fill="#166534" text-anchor="middle">scientific-figure  (Week 8)</text>
+  <text x="255" y="192" font-family="sans-serif" font-size="11.5" font-weight="bold" fill="#166534" text-anchor="middle">Skill = knowledge</text>
+  <text x="255" y="206" font-family="sans-serif" font-size="9.5" fill="#166534" text-anchor="middle">loaded into the room you are already in</text>
+  <text x="255" y="262" font-family="sans-serif" font-size="11" fill="#475569" text-anchor="middle">Claude keeps working, with the procedure in hand.</text>
+
+  <!-- RIGHT: agent in its own context -->
+  <rect x="545" y="74" width="400" height="206" rx="10" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="565" y="98" font-family="sans-serif" font-size="11" font-weight="bold" fill="#64748B">ITS OWN CONTEXT WINDOW</text>
+  <rect x="600" y="120" width="290" height="120" rx="10" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.8"/>
+  <rect x="600" y="120" width="290" height="24" rx="10" fill="#DDD6FE" stroke="#7C3AED" stroke-width="1.8"/>
+  <text x="745" y="137" font-family="monospace" font-size="11" font-weight="bold" fill="#5B21B6" text-anchor="middle">figure-qa  (Week 8)</text>
+  <text x="745" y="164" font-family="sans-serif" font-size="11.5" font-weight="bold" fill="#5B21B6" text-anchor="middle">Agent = a worker</text>
+  <!-- its own tools -->
+  <rect x="620" y="178" width="64" height="20" rx="4" fill="#FFFFFF" stroke="#A78BFA" stroke-width="1"/>
+  <text x="652" y="192" font-family="monospace" font-size="9" fill="#5B21B6" text-anchor="middle">Bash</text>
+  <rect x="694" y="178" width="64" height="20" rx="4" fill="#FFFFFF" stroke="#A78BFA" stroke-width="1"/>
+  <text x="726" y="192" font-family="monospace" font-size="9" fill="#5B21B6" text-anchor="middle">Read</text>
+  <rect x="768" y="178" width="100" height="20" rx="4" fill="#FFFFFF" stroke="#A78BFA" stroke-width="1"/>
+  <text x="818" y="192" font-family="monospace" font-size="9" fill="#5B21B6" text-anchor="middle">own model</text>
+  <text x="745" y="222" font-family="sans-serif" font-size="9.5" fill="#5B21B6" text-anchor="middle">its own context, its own tools, returns a result</text>
+  <text x="745" y="262" font-family="sans-serif" font-size="11" fill="#475569" text-anchor="middle">You delegate a scoped job; it reports back.</text>
+
+  <!-- delegate / result arrows between panels -->
+  <line x1="458" y1="150" x2="542" y2="150" stroke="#7C3AED" stroke-width="2" marker-end="url(#arrow-delegate)"/>
+  <text x="500" y="142" font-family="sans-serif" font-size="9.5" fill="#7C3AED" text-anchor="middle">delegate</text>
+  <line x1="542" y1="205" x2="458" y2="205" stroke="#16A34A" stroke-width="2" marker-end="url(#arrow-result)"/>
+  <text x="500" y="223" font-family="sans-serif" font-size="9.5" fill="#16A34A" text-anchor="middle">result</text>
+
+  <!-- bottom strip -->
+  <rect x="55" y="298" width="890" height="56" rx="6" fill="#F1F5F9" stroke="#94A3B8" stroke-width="0.6"/>
+  <text x="500" y="319" font-family="sans-serif" font-size="11.5" fill="#1E293B" text-anchor="middle" font-weight="bold">Skill = knowledge you keep.   Agent = a job you delegate.</text>
+  <text x="500" y="341" font-family="sans-serif" font-size="10" fill="#64748B" text-anchor="middle">Reach for an agent when the work is isolated, repeatable, or runs in parallel; a skill keeps the procedure with you.</text>
+</svg>

--- a/docs/assets/diagrams/strand-fanout.svg
+++ b/docs/assets/diagrams/strand-fanout.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 280" width="760" height="280">
+  <!-- Title -->
+  <text x="380" y="22" font-family="sans-serif" font-size="13" fill="#1E293B" font-weight="bold" text-anchor="middle">One epic, four strand sub-issues, four collection folders</text>
+
+  <!-- Epic node at top -->
+  <rect x="280" y="40" width="200" height="40" rx="20" fill="#2563EB" stroke="#1D4ED8" stroke-width="1.6"/>
+  <text x="380" y="58" font-family="sans-serif" font-size="12" fill="#FFFFFF" font-weight="bold" text-anchor="middle">Epic: lit-review topic</text>
+  <text x="380" y="72" font-family="monospace" font-size="10" fill="#DBEAFE" text-anchor="middle">issue #N</text>
+
+  <!-- Connector lines from epic to strands -->
+  <path d="M380 80 Q 380 110, 110 110 L 110 134" fill="none" stroke="#CBD5E1" stroke-width="1.6"/>
+  <path d="M380 80 Q 380 110, 290 110 L 290 134" fill="none" stroke="#CBD5E1" stroke-width="1.6"/>
+  <path d="M380 80 Q 380 110, 470 110 L 470 134" fill="none" stroke="#CBD5E1" stroke-width="1.6"/>
+  <path d="M380 80 Q 380 110, 650 110 L 650 134" fill="none" stroke="#CBD5E1" stroke-width="1.6"/>
+
+  <!-- Strand A: Psychophysics -->
+  <g>
+    <rect x="40" y="134" width="140" height="44" rx="6" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.5"/>
+    <circle cx="58" cy="156" r="6" fill="#7C3AED"/>
+    <text x="68" y="151" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold">Strand A</text>
+    <text x="68" y="166" font-family="sans-serif" font-size="10" fill="#475569">Psychophysics</text>
+    <!-- folder under -->
+    <path d="M68 200 L88 200 L92 206 L150 206 L150 230 L68 230 Z" fill="#EDE9FE" stroke="#7C3AED" stroke-width="1.4"/>
+    <text x="109" y="222" font-family="monospace" font-size="9" fill="#5B21B6" text-anchor="middle">collection/psychophysics/</text>
+  </g>
+
+  <!-- Strand B: Action -->
+  <g>
+    <rect x="220" y="134" width="140" height="44" rx="6" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.5"/>
+    <circle cx="238" cy="156" r="6" fill="#F59E0B"/>
+    <text x="248" y="151" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold">Strand B</text>
+    <text x="248" y="166" font-family="sans-serif" font-size="10" fill="#475569">Action</text>
+    <path d="M248 200 L268 200 L272 206 L330 206 L330 230 L248 230 Z" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.4"/>
+    <text x="289" y="222" font-family="monospace" font-size="9" fill="#78350F" text-anchor="middle">collection/action/</text>
+  </g>
+
+  <!-- Strand C: Language -->
+  <g>
+    <rect x="400" y="134" width="140" height="44" rx="6" fill="#FFFFFF" stroke="#059669" stroke-width="1.5"/>
+    <circle cx="418" cy="156" r="6" fill="#059669"/>
+    <text x="428" y="151" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold">Strand C</text>
+    <text x="428" y="166" font-family="sans-serif" font-size="10" fill="#475569">Language</text>
+    <path d="M428 200 L448 200 L452 206 L510 206 L510 230 L428 230 Z" fill="#D1FAE5" stroke="#059669" stroke-width="1.4"/>
+    <text x="469" y="222" font-family="monospace" font-size="9" fill="#064E3B" text-anchor="middle">collection/language/</text>
+  </g>
+
+  <!-- Strand D: Emotion -->
+  <g>
+    <rect x="580" y="134" width="140" height="44" rx="6" fill="#FFFFFF" stroke="#DC2626" stroke-width="1.5"/>
+    <circle cx="598" cy="156" r="6" fill="#DC2626"/>
+    <text x="608" y="151" font-family="sans-serif" font-size="11" fill="#1E293B" font-weight="bold">Strand D</text>
+    <text x="608" y="166" font-family="sans-serif" font-size="10" fill="#475569">Emotion</text>
+    <path d="M608 200 L628 200 L632 206 L690 206 L690 230 L608 230 Z" fill="#FEE2E2" stroke="#DC2626" stroke-width="1.4"/>
+    <text x="649" y="222" font-family="monospace" font-size="9" fill="#7F1D1D" text-anchor="middle">collection/emotion/</text>
+  </g>
+
+  <!-- Caption -->
+  <text x="380" y="262" font-family="sans-serif" font-size="11" fill="#64748B" font-style="italic" text-anchor="middle">Each strand has its own brief, its own folder, its own acceptance criteria.</text>
+</svg>

--- a/docs/assets/diagrams/worktree.svg
+++ b/docs/assets/diagrams/worktree.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- Parent folder: main -->
+  <path d="M70 25 L94 25 L100 33 L130 33 L130 62 L70 62 Z"
+        fill="#FEF3C7" stroke="#92400E" stroke-width="1.8"/>
+  <text x="100" y="51" font-family="monospace" font-size="10" fill="#92400E" font-weight="bold" text-anchor="middle">main</text>
+
+  <!-- Connector lines from main to each child -->
+  <path d="M100 62 L100 88 L42 88 L42 108" fill="none" stroke="#CBD5E1" stroke-width="1.5"/>
+  <path d="M100 62 L100 108" fill="none" stroke="#CBD5E1" stroke-width="1.5"/>
+  <path d="M100 62 L100 88 L158 88 L158 108" fill="none" stroke="#CBD5E1" stroke-width="1.5"/>
+
+  <!-- Child folder: epic-hbn -->
+  <path d="M12 108 L30 108 L34 114 L72 114 L72 148 L12 148 Z"
+        fill="#FEF3C7" stroke="#92400E" stroke-width="1.8"/>
+  <text x="42" y="133" font-family="monospace" font-size="8" fill="#92400E" font-weight="bold" text-anchor="middle">epic-hbn</text>
+  <!-- Branch tag -->
+  <circle cx="66" cy="155" r="4" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.5"/>
+  <text x="42" y="166" font-family="monospace" font-size="6" fill="#2563EB" text-anchor="middle">feature/epic</text>
+  <line x1="50" y1="155" x2="62" y2="155" stroke="#2563EB" stroke-width="1.5"/>
+
+  <!-- Child folder: hbn-phase1 -->
+  <path d="M70 108 L88 108 L92 114 L130 114 L130 148 L70 148 Z"
+        fill="#FEF3C7" stroke="#92400E" stroke-width="1.8"/>
+  <text x="100" y="133" font-family="monospace" font-size="8" fill="#92400E" font-weight="bold" text-anchor="middle">hbn-phase1</text>
+  <circle cx="124" cy="155" r="4" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.5"/>
+  <text x="100" y="166" font-family="monospace" font-size="6" fill="#2563EB" text-anchor="middle">feature/phase1</text>
+  <line x1="108" y1="155" x2="120" y2="155" stroke="#2563EB" stroke-width="1.5"/>
+
+  <!-- Child folder: hbn-phase2 -->
+  <path d="M128 108 L146 108 L150 114 L188 114 L188 148 L128 148 Z"
+        fill="#FEF3C7" stroke="#92400E" stroke-width="1.8"/>
+  <text x="158" y="133" font-family="monospace" font-size="8" fill="#92400E" font-weight="bold" text-anchor="middle">hbn-phase2</text>
+  <circle cx="182" cy="155" r="4" fill="#FFFFFF" stroke="#2563EB" stroke-width="1.5"/>
+  <text x="158" y="166" font-family="monospace" font-size="6" fill="#2563EB" text-anchor="middle">feature/phase2</text>
+  <line x1="166" y1="155" x2="178" y2="155" stroke="#2563EB" stroke-width="1.5"/>
+</svg>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,4 +34,20 @@ uv run mkdocs serve   # http://127.0.0.1:8000/
 uv run mkdocs build --strict
 ```
 
-CI builds and deploys this site to the `gh-pages` branch on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `pyproject.toml`.
+CI builds and deploys this site to the `gh-pages` branch on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `pyproject.toml`. Run `mkdocs build --strict` locally before pushing — it fails on any broken nav entry or image link, which is the easiest way to catch a typo'd path.
+
+## Adding to these docs
+
+A new plugin gets a page at `docs/plugins/<name>.md` following the same skeleton every existing plugin page uses, in this order:
+
+1. `# Title` and a one-paragraph intro (what the plugin does, in plain terms).
+2. One to three workflow sections, each pairing a short explanation with one diagram, if a diagram exists that illustrates that workflow well. Not every section needs one — `presentation.md` has none.
+3. `## Skills` — every skill in the plugin, one bullet each, one line of accurate description. Pull the wording from `README.md`'s existing plugin section rather than re-describing from scratch, so the two don't drift.
+4. `## Try it` — a fenced code block of 2-4 realistic example prompts (or commands, for `project`), taken from or matching the README's examples.
+5. `## Learn more` — a link to the matching [Agentic Research Course](https://courses.osc.earth/agentic-research/) week, if one exists; otherwise say so plainly (see `presentation.md`).
+
+Then add the page to `mkdocs.yml`'s `nav.Plugins` list — nav entries are manual, not auto-discovered.
+
+New diagrams go in `docs/assets/diagrams/` as flat files (no subfolders) and get referenced with a path relative to the current page's depth: `assets/diagrams/foo.svg` from a top-level page like `index.md`, `../assets/diagrams/foo.svg` from a page under `docs/plugins/`. `mkdocs build --strict` catches a wrong relative depth immediately.
+
+If a diagram is reused from an external repo (as the current set is, from `agentic-research-course`), copy it rather than symlinking — a separate repo's files aren't guaranteed to stay at that path — and caption it based on what it actually depicts, not what the surrounding prose would like it to depict. When no existing diagram fits a new section well, prose-only is preferable to a mismatched image.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## Versioning
+
+- Each plugin has independent versioning in its own `plugin.json`.
+- Adding a new plugin or skill is a marketplace minor bump (`0.x.0`).
+- A version bump within an existing plugin is a marketplace patch bump (`0.x.y`).
+- Bumps don't propagate upward by default — a skill patch doesn't automatically bump its plugin, and a plugin bump doesn't automatically bump the marketplace, beyond the rule above.
+
+## Releases and citation
+
+- The marketplace version lives in `.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json` (the Codex `.agents/plugins/marketplace.json` carries no top-level version).
+- GitHub release tags mirror the marketplace top-level version — marketplace `0.15.12` gets tag `v0.15.12`, not a separately incrementing release sequence.
+- The repository is archived to Zenodo on every GitHub release, minting a versioned DOI under a stable concept DOI. When the marketplace version bumps for a release, `CITATION.cff`'s `version` and `date-released` fields get bumped alongside it, and `.zenodo.json` stays in sync.
+- The concept DOI (in `CITATION.cff`'s `doi:` field and the README badge) is stable across versions and does not change.
+
+## Development conventions
+
+- Detailed project rules live in `.rules/` — check the relevant rule file before changing manifests, skills, agents, tests, CI, or language tooling.
+- Use [Bun](https://bun.sh/) for JavaScript/TypeScript work; see `.rules/javascript.md`.
+- Use [UV](https://docs.astral.sh/uv/) for Python work (this docs site included); see `.rules/python.md`.
+- No mocks in tests — see `.rules/testing.md`.
+- No emojis in commits or code — see `.rules/git.md`.
+
+## Cross-agent compatibility
+
+Any plugin update must check Claude Code, Codex, and GitHub Copilot CLI manifests and install paths together — see [Cross-Agent Compatibility](cross-agent-compatibility.md) for the researched registration paths, and `.rules/cross-agent-compatibility.md` for the update policy itself.
+
+## Building these docs locally
+
+```bash
+uv sync --group docs
+uv run mkdocs serve   # http://127.0.0.1:8000/
+uv run mkdocs build --strict
+```
+
+CI builds and deploys this site to the `gh-pages` branch on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `pyproject.toml`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,26 +5,26 @@
 - Each plugin has independent versioning in its own `plugin.json`.
 - Adding a new plugin or skill is a marketplace minor bump (`0.x.0`).
 - A version bump within an existing plugin is a marketplace patch bump (`0.x.y`).
-- Bumps don't propagate upward by default — a skill patch doesn't automatically bump its plugin, and a plugin bump doesn't automatically bump the marketplace, beyond the rule above.
+- Bumps don't propagate upward by default: a skill patch doesn't automatically bump its plugin, and a plugin bump doesn't automatically bump the marketplace, beyond the rule above.
 
 ## Releases and citation
 
 - The marketplace version lives in `.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json` (the Codex `.agents/plugins/marketplace.json` carries no top-level version).
-- GitHub release tags mirror the marketplace top-level version — marketplace `0.15.12` gets tag `v0.15.12`, not a separately incrementing release sequence.
+- GitHub release tags mirror the marketplace top-level version: marketplace `0.15.12` gets tag `v0.15.12`, not a separately incrementing release sequence.
 - The repository is archived to Zenodo on every GitHub release, minting a versioned DOI under a stable concept DOI. When the marketplace version bumps for a release, `CITATION.cff`'s `version` and `date-released` fields get bumped alongside it, and `.zenodo.json` stays in sync.
 - The concept DOI (in `CITATION.cff`'s `doi:` field and the README badge) is stable across versions and does not change.
 
 ## Development conventions
 
-- Detailed project rules live in `.rules/` — check the relevant rule file before changing manifests, skills, agents, tests, CI, or language tooling.
+- Detailed project rules live in `.rules/`; check the relevant rule file before changing manifests, skills, agents, tests, CI, or language tooling.
 - Use [Bun](https://bun.sh/) for JavaScript/TypeScript work; see `.rules/javascript.md`.
 - Use [UV](https://docs.astral.sh/uv/) for Python work (this docs site included); see `.rules/python.md`.
-- No mocks in tests — see `.rules/testing.md`.
-- No emojis in commits or code — see `.rules/git.md`.
+- No mocks in tests; see `.rules/testing.md`.
+- No emojis in commits or code; see `.rules/git.md`.
 
 ## Cross-agent compatibility
 
-Any plugin update must check Claude Code, Codex, and GitHub Copilot CLI manifests and install paths together — see [Cross-Agent Compatibility](cross-agent-compatibility.md) for the researched registration paths, and `.rules/cross-agent-compatibility.md` for the update policy itself.
+Any plugin update must check Claude Code, Codex, and GitHub Copilot CLI manifests and install paths together; see [Cross-Agent Compatibility](cross-agent-compatibility.md) for the researched registration paths, and `.rules/cross-agent-compatibility.md` for the update policy itself.
 
 ## Building these docs locally
 
@@ -34,20 +34,20 @@ uv run mkdocs serve   # http://127.0.0.1:8000/
 uv run mkdocs build --strict
 ```
 
-CI builds and deploys this site to the `gh-pages` branch on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `pyproject.toml`. Run `mkdocs build --strict` locally before pushing — it fails on any broken nav entry or image link, which is the easiest way to catch a typo'd path.
+CI builds and deploys this site to the `gh-pages` branch on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `pyproject.toml`. Run `mkdocs build --strict` locally before pushing; it fails on any broken nav entry or image link, which is the easiest way to catch a typo'd path.
 
 ## Adding to these docs
 
 A new plugin gets a page at `docs/plugins/<name>.md` following the same skeleton every existing plugin page uses, in this order:
 
 1. `# Title` and a one-paragraph intro (what the plugin does, in plain terms).
-2. One to three workflow sections, each pairing a short explanation with one diagram, if a diagram exists that illustrates that workflow well. Not every section needs one — `presentation.md` has none.
-3. `## Skills` — every skill in the plugin, one bullet each, one line of accurate description. Pull the wording from `README.md`'s existing plugin section rather than re-describing from scratch, so the two don't drift.
-4. `## Try it` — a fenced code block of 2-4 realistic example prompts (or commands, for `project`), taken from or matching the README's examples.
-5. `## Learn more` — a link to the matching [Agentic Research Course](https://courses.osc.earth/agentic-research/) week, if one exists; otherwise say so plainly (see `presentation.md`).
+2. All of the plugin's workflow sections, one to three of them, each pairing a short explanation with one diagram, if a diagram exists that illustrates that workflow well. Not every section needs one; `presentation.md` has none.
+3. `## Skills`, after every workflow section, not interleaved with them: every skill in the plugin, one bullet each, one line of accurate description. Pull the wording from `README.md`'s existing plugin section rather than re-describing from scratch, so the two don't drift.
+4. `## Try it`: a fenced code block of 2-4 realistic example prompts (or commands, for `project`), taken from or matching the README's examples.
+5. `## Learn more`: a link to the matching [Agentic Research Course](https://courses.osc.earth/agentic-research/) week, if one exists; otherwise say so plainly (see `presentation.md`).
 
-Then add the page to `mkdocs.yml`'s `nav.Plugins` list — nav entries are manual, not auto-discovered.
+Then add the page to `mkdocs.yml`'s `nav.Plugins` list; nav entries are manual, not auto-discovered.
 
 New diagrams go in `docs/assets/diagrams/` as flat files (no subfolders) and get referenced with a path relative to the current page's depth: `assets/diagrams/foo.svg` from a top-level page like `index.md`, `../assets/diagrams/foo.svg` from a page under `docs/plugins/`. `mkdocs build --strict` catches a wrong relative depth immediately.
 
-If a diagram is reused from an external repo (as the current set is, from `agentic-research-course`), copy it rather than symlinking — a separate repo's files aren't guaranteed to stay at that path — and caption it based on what it actually depicts, not what the surrounding prose would like it to depict. When no existing diagram fits a new section well, prose-only is preferable to a mismatched image.
+If a diagram is reused from an external repo (as the current set is, from `agentic-research-course`), copy it rather than symlinking, since a separate repo's files aren't guaranteed to stay at that path, and caption it based on what it actually depicts, not what the surrounding prose would like it to depict. When no existing diagram fits a new section well, prose-only is preferable to a mismatched image.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,7 @@ See [Cross-Agent Compatibility](cross-agent-compatibility.md) for the researched
 
 ## Skills vs. commands
 
-This marketplace follows a skills-first surface: skills auto-trigger from natural-language intent, described by matching the task you describe against each skill's frontmatter. There is no explicit invocation step for most work. Commands exist only where a workflow needs an explicit `/command args` entry point — project init, epic/sprint management, and version bumps.
+This marketplace follows a skills-first surface: skills auto-trigger from natural-language intent, described by matching the task you describe against each skill's frontmatter. There is no explicit invocation step for most work. Commands exist only where a workflow needs an explicit `/command args` entry point: project init, epic/sprint management, and version bumps.
 
 For example, once the `manuscript` plugin is installed, saying "review this manuscript at paper.pdf as a peer reviewer" triggers the `paper-review` skill directly. There is no `/review-paper` command to remember or look up.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,55 @@
+# Getting Started
+
+## Install
+
+### Claude Code
+
+In Claude Code, type `/plugin`, select **Add marketplace**, enter:
+
+```
+neuromechanist/research-skills
+```
+
+Then select which plugins to install. Each plugin is independent.
+
+Install all plugins via CLI:
+
+```bash
+claude plugin marketplace add neuromechanist/research-skills
+for p in project grant manuscript opencite figures presentation neuroinformatics; do
+  claude plugin install "$p@research-skills"
+done
+```
+
+### Codex
+
+Codex can use the native repo marketplace at `.agents/plugins/marketplace.json`; the Claude-compatible `.claude-plugin/marketplace.json` remains for legacy-compatible installs.
+
+```bash
+codex plugin marketplace add neuromechanist/research-skills
+codex plugin marketplace add ./path/to/research-skills
+```
+
+Each plugin also has a native `.codex-plugin/plugin.json` manifest. Open `/plugins` in Codex and install the plugins you need.
+
+### GitHub Copilot CLI
+
+Copilot CLI can use the native marketplace at `.github/plugin/marketplace.json`. Each plugin also has a native `.github/plugin/plugin.json` manifest.
+
+```bash
+copilot plugin marketplace add neuromechanist/research-skills
+copilot plugin marketplace browse research-skills
+copilot plugin install project@research-skills
+```
+
+See [Cross-Agent Compatibility](cross-agent-compatibility.md) for the researched registration paths and source links behind each of these install commands.
+
+## Skills vs. commands
+
+This marketplace follows a skills-first surface: skills auto-trigger from natural-language intent, described by matching the task you describe against each skill's frontmatter. There is no explicit invocation step for most work. Commands exist only where a workflow needs an explicit `/command args` entry point — project init, epic/sprint management, and version bumps.
+
+For example, once the `manuscript` plugin is installed, saying "review this manuscript at paper.pdf as a peer reviewer" triggers the `paper-review` skill directly. There is no `/review-paper` command to remember or look up.
+
+## Requirements
+
+Each plugin's runtime tooling requirements (the `opencite` CLI, Inkscape/cairosvg, PsychoPy, `bids-validator`, and so on) are noted on that plugin's own page. See the [README's Requirements section](https://github.com/neuromechanist/research-skills#requirements) for the full consolidated list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Research Skills
+
+Research Skills is a cross-agent plugin marketplace for academic research and development workflows. It ships **skills** — agent-callable capabilities that auto-trigger from natural-language intent — covering the parts of a research group's work that AI coding agents are good at automating: literature search, grant writing, manuscript preparation, publication figures, presentations, project lifecycle management, and neuroinformatics data standards.
+
+It targets three agent runtimes from one shared set of skill definitions: [Claude Code](https://claude.com/claude-code), [OpenAI Codex](https://developers.openai.com/codex), and [GitHub Copilot CLI](https://docs.github.com/en/copilot).
+
+!!! tip "Learn it hands-on"
+    This marketplace is taught week-by-week in the free [Agentic Research Course](https://courses.osc.earth/agentic-research/) from the Open Science Collective.
+
+## Plugins
+
+| Plugin | What it does |
+|---|---|
+| [Project](plugins/project.md) | Epics/worktrees, PR review, CI/CD, debugging, agent fan-out |
+| [Grant](plugins/grant.md) | NIH/NSF proposal writing, review, figure QA |
+| [Manuscript](plugins/manuscript.md) | Literature review, peer review, writing, journal formatting |
+| [Opencite](plugins/opencite.md) | Literature search, citation management, PDF retrieval |
+| [Figures](plugins/figures.md) | Publication-quality figure composition and QA |
+| [Presentation](plugins/presentation.md) | Interactive Reveal.js slide decks |
+| [Neuroinformatics](plugins/neuroinformatics.md) | BIDS conversion, HED annotation, experiment design |
+
+Start with [Getting Started](getting-started.md) to install a plugin, or [Architecture](architecture.md) to see how skills, commands, agents, and MCP servers fit together.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Research Skills
 
-Research Skills is a cross-agent plugin marketplace for academic research and development workflows. It ships **skills** — agent-callable capabilities that auto-trigger from natural-language intent — covering the parts of a research group's work that AI coding agents are good at automating: literature search, grant writing, manuscript preparation, publication figures, presentations, project lifecycle management, and neuroinformatics data standards.
+Research Skills is a cross-agent plugin marketplace for academic research and development workflows. It ships **skills**, agent-callable capabilities that auto-trigger from natural-language intent, covering the parts of a research group's work that AI coding agents are good at automating: literature search, grant writing, manuscript preparation, publication figures, presentations, project lifecycle management, and neuroinformatics data standards.
 
 It targets three agent runtimes from one shared set of skill definitions: [Claude Code](https://claude.com/claude-code), [OpenAI Codex](https://developers.openai.com/codex), and [GitHub Copilot CLI](https://docs.github.com/en/copilot).
 

--- a/docs/plugins/figures.md
+++ b/docs/plugins/figures.md
@@ -1,0 +1,54 @@
+# Figures
+
+The `figures` plugin composes publication-quality figures at exact journal dimensions (Nature, Science, PNAS, Cell, and others) and QAs them before they go anywhere near a submission.
+
+## The figure pipeline
+
+A figure moves through five steps, each with its own mechanical defense against the most common failure at that step, and a boomerang from validation straight back to building when a font fails:
+
+![Figure pipeline: Plan, Build, Compose, Validate, Export, with a boomerang from Validate back to Build on font failure](../assets/diagrams/figures-pipeline.svg)
+
+1. **Plan** — journal, size, panel grid, palette and theme
+2. **Build** — `plot-styling` for data plots, `svg-figure`/`svg-primitives` for schematics, icons, or an AI-generated substrate
+3. **Compose** — `svgutils` places panels at exact mm coordinates, with text preserved as inspectable `<text>` elements
+4. **Validate** — `validate_fonts.py` reports the effective point size against the journal minimum
+5. **Export** — Inkscape when available on `$PATH`, `cairosvg` fallback otherwise
+
+When the validator fails, the fix is mechanical: rescale the panel up, increase the source point size, or widen the canvas — not a redesign.
+
+## Five skills, one QA agent
+
+The plugin is a composer at the center, four element-builder skills that feed it, and a QA agent that runs on every figure regardless of how it was built:
+
+![Figures plugin map: scientific-figure composer at the center, fed by plot-styling, svg-figure, transparent-icons, and ai-full-figure, with figure-qa running on every output](../assets/diagrams/figures-plugin-map.svg)
+
+- **scientific-figure** — the composer (the sink): `svgutils`-based, exact mm coordinates, `validate_fonts.py` before export, Inkscape/cairosvg backend
+- **plot-styling** — data plots via matplotlib, seaborn, plotnine, plotly, or PyVista, with SciencePlots recipes for Nature/IEEE/Science/Cell/PNAS/APS
+- **svg-figure** / **svg-primitives** — hand-authored or programmatic schematics: boxes, arrows, and labels in SVG, with `svg-primitives` preferred for new work (mm-precise, auto-fit text, tangent-correct arrows, in-process validation)
+- **transparent-icons** — flat scientific icons via the Codex CLI `image_gen` tool or the OpenAI Images API, with Pillow-threshold or opt-in `rembg`+BiRefNet transparency
+- **ai-full-figure** — an AI-generated pictorial substrate plus programmatic label/arrow/scale-bar overlay, so the model never hallucinates the labels themselves
+
+## How figure-qa decides what to check
+
+`figure-qa` dispatches on input type, runs the matching deterministic check script, then always adds a VLM aesthetic pass on top:
+
+![Figure QA dispatch: detects SVG, raster, plot-script, or composed-figure-directory input, runs the matching check script, then a VLM aesthetic pass on every input type](../assets/diagrams/figure-qa-dispatch.svg)
+
+- **SVG** → `check_svg.py` (bbox / arrow-tip-to-target / point size / palette)
+- **Raster** (PNG/JPG/TIFF) → `check_raster.py` (DPI / embedded fonts / alpha channel)
+- **Plot script** → `check_plot_script.py` (`savefig` kwargs / rcParams)
+- **Composed-figure directory** → all of the above, per panel
+
+Programmatic checks own anything with ground truth (font minima, palette compliance, geometry); the VLM judgment pass is reserved for "does this look balanced" — hierarchy, alignment, palette coherence, journal fit.
+
+## Try it
+
+```
+"Create a Nature 2-column figure with 3 panels showing EEG spectrograms"
+"QA this figure for Science submission requirements"
+"Generate a transparent icon of a neuron for my poster"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 8, "Scientific Figures," covers this plugin hands-on.

--- a/docs/plugins/figures.md
+++ b/docs/plugins/figures.md
@@ -8,28 +8,19 @@ A figure moves through five steps, each with its own mechanical defense against 
 
 ![Figure pipeline: Plan, Build, Compose, Validate, Export, with a boomerang from Validate back to Build on font failure](../assets/diagrams/figures-pipeline.svg)
 
-1. **Plan** — journal, size, panel grid, palette and theme
-2. **Build** — `plot-styling` for data plots, `svg-figure`/`svg-primitives` for schematics, icons, or an AI-generated substrate
-3. **Compose** — `svgutils` places panels at exact mm coordinates, with text preserved as inspectable `<text>` elements
-4. **Validate** — `validate_fonts.py` reports the effective point size against the journal minimum
-5. **Export** — Inkscape when available on `$PATH`, `cairosvg` fallback otherwise
+1. **Plan**: journal, size, panel grid, palette and theme
+2. **Build**: `plot-styling` for data plots, `svg-figure`/`svg-primitives` for schematics, icons, or an AI-generated substrate
+3. **Compose**: `svgutils` places panels at exact mm coordinates, with text preserved as inspectable `<text>` elements
+4. **Validate**: `validate_fonts.py` reports the effective point size against the journal minimum
+5. **Export**: Inkscape when available on `$PATH`, `cairosvg` fallback otherwise
 
-When the validator fails, the fix is mechanical: rescale the panel up, increase the source point size, or widen the canvas — not a redesign.
+When the validator fails, the fix is mechanical: rescale the panel up, increase the source point size, or widen the canvas, not a redesign.
 
 ## The plugin map
 
 The plugin is a composer at the center, four element-builder skills that feed it, and a QA agent that runs on every figure regardless of how it was built:
 
 ![Figures plugin map: scientific-figure composer at the center, fed by plot-styling, svg-figure, transparent-icons, and ai-full-figure, with figure-qa running on every output](../assets/diagrams/figures-plugin-map.svg)
-
-## Skills
-
-- **scientific-figure** — the composer (the sink): `svgutils`-based, exact mm coordinates, `validate_fonts.py` before export, Inkscape/cairosvg backend
-- **plot-styling** — data plots via matplotlib, seaborn, plotnine, plotly, or PyVista, with SciencePlots recipes for Nature/IEEE/Science/Cell/PNAS/APS
-- **svg-figure** / **svg-primitives** — hand-authored or programmatic schematics: boxes, arrows, and labels in SVG, with `svg-primitives` preferred for new work (mm-precise, auto-fit text, tangent-correct arrows, in-process validation)
-- **transparent-icons** — flat scientific icons via the Codex CLI `image_gen` tool or the OpenAI Images API, with Pillow-threshold or opt-in `rembg`+BiRefNet transparency
-- **ai-full-figure** — an AI-generated pictorial substrate plus programmatic label/arrow/scale-bar overlay, so the model never hallucinates the labels themselves
-- **figure-qa** — the QA agent described below, run against every figure regardless of how it was built
 
 ## How figure-qa decides what to check
 
@@ -42,7 +33,16 @@ The plugin is a composer at the center, four element-builder skills that feed it
 - **Plot script** → `check_plot_script.py` (`savefig` kwargs / rcParams)
 - **Composed-figure directory** → all of the above, per panel
 
-Programmatic checks own anything with ground truth (font minima, palette compliance, geometry); the VLM judgment pass is reserved for "does this look balanced" — hierarchy, alignment, palette coherence, journal fit.
+Programmatic checks own anything with ground truth (font minima, palette compliance, geometry); the VLM judgment pass is reserved for "does this look balanced": hierarchy, alignment, palette coherence, journal fit.
+
+## Skills
+
+- **scientific-figure**: the composer (the sink): `svgutils`-based, exact mm coordinates, `validate_fonts.py` before export, Inkscape/cairosvg backend
+- **plot-styling**: data plots via matplotlib, seaborn, plotnine, plotly, or PyVista, with SciencePlots recipes for Nature/IEEE/Science/Cell/PNAS/APS
+- **svg-figure** / **svg-primitives**: hand-authored or programmatic schematics: boxes, arrows, and labels in SVG, with `svg-primitives` preferred for new work (mm-precise, auto-fit text, tangent-correct arrows, in-process validation)
+- **transparent-icons**: flat scientific icons via the Codex CLI `image_gen` tool or the OpenAI Images API, with Pillow-threshold or opt-in `rembg`+BiRefNet transparency
+- **ai-full-figure**: an AI-generated pictorial substrate plus programmatic label/arrow/scale-bar overlay, so the model never hallucinates the labels themselves
+- **figure-qa**: the QA agent described above, run against every figure regardless of how it was built
 
 ## Try it
 

--- a/docs/plugins/figures.md
+++ b/docs/plugins/figures.md
@@ -16,17 +16,20 @@ A figure moves through five steps, each with its own mechanical defense against 
 
 When the validator fails, the fix is mechanical: rescale the panel up, increase the source point size, or widen the canvas — not a redesign.
 
-## Five skills, one QA agent
+## The plugin map
 
 The plugin is a composer at the center, four element-builder skills that feed it, and a QA agent that runs on every figure regardless of how it was built:
 
 ![Figures plugin map: scientific-figure composer at the center, fed by plot-styling, svg-figure, transparent-icons, and ai-full-figure, with figure-qa running on every output](../assets/diagrams/figures-plugin-map.svg)
+
+## Skills
 
 - **scientific-figure** — the composer (the sink): `svgutils`-based, exact mm coordinates, `validate_fonts.py` before export, Inkscape/cairosvg backend
 - **plot-styling** — data plots via matplotlib, seaborn, plotnine, plotly, or PyVista, with SciencePlots recipes for Nature/IEEE/Science/Cell/PNAS/APS
 - **svg-figure** / **svg-primitives** — hand-authored or programmatic schematics: boxes, arrows, and labels in SVG, with `svg-primitives` preferred for new work (mm-precise, auto-fit text, tangent-correct arrows, in-process validation)
 - **transparent-icons** — flat scientific icons via the Codex CLI `image_gen` tool or the OpenAI Images API, with Pillow-threshold or opt-in `rembg`+BiRefNet transparency
 - **ai-full-figure** — an AI-generated pictorial substrate plus programmatic label/arrow/scale-bar overlay, so the model never hallucinates the labels themselves
+- **figure-qa** — the QA agent described below, run against every figure regardless of how it was built
 
 ## How figure-qa decides what to check
 

--- a/docs/plugins/grant.md
+++ b/docs/plugins/grant.md
@@ -1,0 +1,50 @@
+# Grant
+
+The `grant` plugin drafts and reviews NIH and NSF grant proposals with mechanism-specific templates (R01, R21, K99, CAREER, and more), plus a figure-QA skill scoped to grant-specific compliance checks.
+
+## The proposal pipeline
+
+Writing a proposal is a five-stage managed pipeline, with review findings boomeranging back to an earlier stage rather than being patched in place:
+
+![Grant pipeline: NOFO, Aims, Strategy, Self-review, Figure QA, with a boomerang from review findings back to an earlier stage](../assets/diagrams/grant-pipeline.svg)
+
+1. **NOFO** — read the funding opportunity as a contract
+2. **Aims** — one page, three aims
+3. **Strategy** — significance, innovation, and approach, scored 1-9
+4. **Self-review** — a study-section simulation via `grant-review`
+5. **Figure QA** — resolution, fonts, colorblind-safe palettes via `grant-figure-qa`
+
+Order is enforced; a self-review that cycles back to an earlier stage is the rigor signal working as intended, not a setback.
+
+Findings from the self-review stage are severity-tagged, and the severity determines where they cycle back to:
+
+![Grant review boomerang: critical findings cycle back to Aims, major findings to Strategy, minor findings get an in-place edit with no cycle](../assets/diagrams/grant-boomerang.svg)
+
+- **Critical** — revise the Aims
+- **Major** — tighten the Approach
+- **Minor** — edit in place, no cycle needed
+
+## How NIH scores a proposal
+
+`grant-review`'s NIH rubric mirrors how an actual study section scores a proposal: five criteria, each 1-9, rolled into one integrated impact score.
+
+![NIH study section scoring: Significance, Investigator, Innovation, Approach, Environment, each scored 1 (exceptional) to 9 (poor), rolled into an integrated impact score](../assets/diagrams/nih-scoring.svg)
+
+A 1 in any single criterion does not save a 5 in Approach — reviewers tie everything back to the integrated impact score, not the best individual criterion. (As of the 2025 Simplified Review Framework, RPG mechanisms score three factors — Importance, Rigor & Feasibility, and Expertise & Resources — rather than the five shown here; F fellowships and T training grants follow their own separately revised frameworks. See the `grant-review` skill for the current mechanism-specific rubric.)
+
+## Skills
+
+- **grant-writing** — research strategy guidelines, writing style, budget justification, and resubmission response, with mechanism-specific templates
+- **grant-review** — the NIH/NSF study-section simulation described above; a thin-dispatch skill with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template — when no agent is configured, the skill runs the same reference procedure inline
+- **grant-figure-qa** — checks figures for resolution, accessibility, and NIH/NSF compliance, following the same dispatch pattern as `grant-review`
+
+## Try it
+
+```
+"Write the significance section for an R01 on motor cortex"
+"Review my R21 proposal at proposal.pdf as an NIH study section"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 6, "Grant Proposal Writing," walks through NIH/NSF proposals hands-on.

--- a/docs/plugins/grant.md
+++ b/docs/plugins/grant.md
@@ -8,11 +8,11 @@ Writing a proposal is a five-stage managed pipeline, with review findings boomer
 
 ![Grant pipeline: NOFO, Aims, Strategy, Self-review, Figure QA, with a boomerang from review findings back to an earlier stage](../assets/diagrams/grant-pipeline.svg)
 
-1. **NOFO** — read the funding opportunity as a contract
-2. **Aims** — one page, three aims
-3. **Strategy** — significance, innovation, and approach, scored 1-9
-4. **Self-review** — a study-section simulation via `grant-review`
-5. **Figure QA** — resolution, fonts, colorblind-safe palettes via `grant-figure-qa`
+1. **NOFO**: read the funding opportunity as a contract
+2. **Aims**: one page, three aims
+3. **Strategy**: significance, innovation, and approach, scored 1-9
+4. **Self-review**: a study-section simulation via `grant-review`
+5. **Figure QA**: resolution, fonts, colorblind-safe palettes via `grant-figure-qa`
 
 Order is enforced; a self-review that cycles back to an earlier stage is the rigor signal working as intended, not a setback.
 
@@ -20,9 +20,9 @@ Findings from the self-review stage are severity-tagged, and the severity determ
 
 ![Grant review boomerang: critical findings cycle back to Aims, major findings to Strategy, minor findings get an in-place edit with no cycle](../assets/diagrams/grant-boomerang.svg)
 
-- **Critical** — revise the Aims
-- **Major** — tighten the Approach
-- **Minor** — edit in place, no cycle needed
+- **Critical**: revise the Aims
+- **Major**: tighten the Approach
+- **Minor**: edit in place, no cycle needed
 
 ## How NIH scores a proposal
 
@@ -30,13 +30,13 @@ Findings from the self-review stage are severity-tagged, and the severity determ
 
 ![NIH study section scoring: Significance, Investigator, Innovation, Approach, Environment, each scored 1 (exceptional) to 9 (poor), rolled into an integrated impact score](../assets/diagrams/nih-scoring.svg)
 
-A 1 in any single criterion does not save a 5 in Approach — reviewers tie everything back to the integrated impact score, not the best individual criterion. (As of the 2025 Simplified Review Framework, RPG mechanisms score three factors — Importance, Rigor & Feasibility, and Expertise & Resources — rather than the five shown here; F fellowships and T training grants follow their own separately revised frameworks. See the `grant-review` skill for the current mechanism-specific rubric.)
+A 1 in any single criterion does not save a 5 in Approach; reviewers tie everything back to the integrated impact score, not the best individual criterion. (As of the 2025 Simplified Review Framework, RPG mechanisms score three factors, Importance, Rigor & Feasibility, and Expertise & Resources, rather than the five shown here; F fellowships and T training grants follow their own separately revised frameworks. See the `grant-review` skill for the current mechanism-specific rubric.)
 
 ## Skills
 
-- **grant-writing** — research strategy guidelines, writing style, budget justification, and resubmission response, with mechanism-specific templates
-- **grant-review** — the NIH/NSF study-section simulation described above; a thin-dispatch skill with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template — when no agent is configured, the skill runs the same reference procedure inline
-- **grant-figure-qa** — checks figures for resolution, accessibility, and NIH/NSF compliance, following the same dispatch pattern as `grant-review`
+- **grant-writing**: research strategy guidelines, writing style, budget justification, and resubmission response, with mechanism-specific templates
+- **grant-review**: the NIH/NSF study-section simulation described above; a thin-dispatch skill with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template; when no agent is configured, the skill runs the same reference procedure inline
+- **grant-figure-qa**: checks figures for resolution, accessibility, and NIH/NSF compliance, following the same dispatch pattern as `grant-review`
 
 ## Try it
 

--- a/docs/plugins/manuscript.md
+++ b/docs/plugins/manuscript.md
@@ -4,21 +4,21 @@ The `manuscript` plugin covers the full manuscript lifecycle: literature review,
 
 ## The manuscript pipeline
 
-Like the grant pipeline, a manuscript moves through five managed stages, but it crosses a loop boundary partway through: the first four stages are an agent + author co-writing loop inside the repo (GitHub-native — epics, sub-issues, worktrees, `pr-review-toolkit`, the `manuscript:*` and `figures:*` skills), and the last stage hands off to a human co-author review loop in Overleaf.
+Like the grant pipeline, a manuscript moves through five managed stages, but it crosses a loop boundary partway through: the first four stages are an agent + author co-writing loop inside the repo (GitHub-native: epics, sub-issues, worktrees, `pr-review-toolkit`, the `manuscript:*` and `figures:*` skills), and the last stage hands off to a human co-author review loop in Overleaf.
 
 ![Manuscript pipeline: Lit review, Draft, Figures, Self-review as an agent loop inside GitHub, then Format & submit as a human loop in Overleaf, with a boomerang from review findings](../assets/diagrams/manuscript-pipeline.svg)
 
-1. **Lit review** — paper-cards (see below)
-2. **Draft** — IMRAD sections
-3. **Figures** — sourced in-repo
-4. **Self-review** — `paper-review`
-5. **Format & submit** — zip export, then Overleaf; co-authors review the Overleaf copy and changes get cloned back to the repo
+1. **Lit review**: paper-cards (see below)
+2. **Draft**: IMRAD sections
+3. **Figures**: sourced in-repo
+4. **Self-review**: `paper-review`
+5. **Format & submit**: zip export, then Overleaf; co-authors review the Overleaf copy and changes get cloned back to the repo
 
 As with grants, `paper-review` findings are severity-tagged and cycle back to a specific earlier stage rather than being patched wherever they surface:
 
 ![Manuscript review boomerang: critical findings on unsupported claims cycle to lit review or the draft, major findings on figure mismatches cycle to figures, minor prose findings are edited in place](../assets/diagrams/manuscript-boomerang.svg)
 
-Convergence in one review pass is treated as a red flag, not a good sign — critical findings should cycle back to collection or drafting, major findings back to figures, and only minor prose issues (like a stray em dash the humanizer missed) get edited in place.
+Convergence in one review pass is treated as a red flag, not a good sign: critical findings should cycle back to collection or drafting, major findings back to figures, and only minor prose issues (like a stray em dash the humanizer missed) get edited in place.
 
 ## Literature review, in two modes
 
@@ -26,7 +26,7 @@ Convergence in one review pass is treated as a red flag, not a good sign — cri
 
 ![Literature review pipeline: Direction, Collect, Synthesize, Draft, Review, with gaps found in review boomeranging back to collection, not just the prose](../assets/diagrams/lit-review-pipeline.svg)
 
-Every claim in a multi-phase review must trace back to a paper-card on disk — a schema-enforced markdown file with YAML front matter (slug, type, year, DOI, license, relevance, PDF status) and six required sections, validated by `opencite`:
+Every claim in a multi-phase review must trace back to a paper-card on disk: a schema-enforced markdown file with YAML front matter (slug, type, year, DOI, license, relevance, PDF status) and six required sections, validated by `opencite`:
 
 ![Paper-card anatomy: YAML front matter plus TL;DR, Summary, Relevance, Notable details, Open questions, and Citations sections, the same shape across every card](../assets/diagrams/paper-card-anatomy.svg)
 
@@ -34,11 +34,11 @@ The same shape across every card is what lets synthesis scan the corpus quickly 
 
 ## Skills
 
-- **lit-review** — both literature-review modes described above
-- **manuscript-writing** — IMRAD structure and section templates
-- **paper-review** — the peer-review simulation described above; thin-dispatch with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template
-- **manuscript-formatting** — journal-specific formatting (IEEE, Nature, PNAS, Elsevier, LaTeX/BibTeX management) plus revision-response templates
-- **humanizer** — a final natural-writing pass that removes AI-writing tells while preserving meaning and discipline conventions
+- **lit-review**: both literature-review modes described above
+- **manuscript-writing**: IMRAD structure and section templates
+- **paper-review**: the peer-review simulation described above; thin-dispatch with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template
+- **manuscript-formatting**: journal-specific formatting (IEEE, Nature, PNAS, Elsevier, LaTeX/BibTeX management) plus revision-response templates
+- **humanizer**: a final natural-writing pass that removes AI-writing tells while preserving meaning and discipline conventions
 
 ## Try it
 

--- a/docs/plugins/manuscript.md
+++ b/docs/plugins/manuscript.md
@@ -1,0 +1,54 @@
+# Manuscript
+
+The `manuscript` plugin covers the full manuscript lifecycle: literature review, writing (IMRAD structure, section templates), peer review (methodology, statistics, reproducibility), journal-specific formatting, and a final humanizer pass that strips AI-writing tells.
+
+## The manuscript pipeline
+
+Like the grant pipeline, a manuscript moves through five managed stages, but it crosses a loop boundary partway through: the first four stages are an agent + author co-writing loop inside the repo (GitHub-native — epics, sub-issues, worktrees, `pr-review-toolkit`, the `manuscript:*` and `figures:*` skills), and the last stage hands off to a human co-author review loop in Overleaf.
+
+![Manuscript pipeline: Lit review, Draft, Figures, Self-review as an agent loop inside GitHub, then Format & submit as a human loop in Overleaf, with a boomerang from review findings](../assets/diagrams/manuscript-pipeline.svg)
+
+1. **Lit review** — paper-cards (see below)
+2. **Draft** — IMRAD sections
+3. **Figures** — sourced in-repo
+4. **Self-review** — `paper-review`
+5. **Format & submit** — zip export, then Overleaf; co-authors review the Overleaf copy and changes get cloned back to the repo
+
+As with grants, `paper-review` findings are severity-tagged and cycle back to a specific earlier stage rather than being patched wherever they surface:
+
+![Manuscript review boomerang: critical findings on unsupported claims cycle to lit review or the draft, major findings on figure mismatches cycle to figures, minor prose findings are edited in place](../assets/diagrams/manuscript-boomerang.svg)
+
+Convergence in one review pass is treated as a red flag, not a good sign — critical findings should cycle back to collection or drafting, major findings back to figures, and only minor prose issues (like a stray em dash the humanizer missed) get edited in place.
+
+## Literature review, in two modes
+
+`manuscript:lit-review` covers two workflows: a rigorous, citation-traceable multi-phase protocol, and an express single-pass synthesis for writing an Introduction or Background section. The multi-phase mode is itself a five-stage pipeline that can delegate its epic/sub-issue/worktree orchestration to `project:epic-dev`:
+
+![Literature review pipeline: Direction, Collect, Synthesize, Draft, Review, with gaps found in review boomeranging back to collection, not just the prose](../assets/diagrams/lit-review-pipeline.svg)
+
+Every claim in a multi-phase review must trace back to a paper-card on disk — a schema-enforced markdown file with YAML front matter (slug, type, year, DOI, license, relevance, PDF status) and six required sections, validated by `opencite`:
+
+![Paper-card anatomy: YAML front matter plus TL;DR, Summary, Relevance, Notable details, Open questions, and Citations sections, the same shape across every card](../assets/diagrams/paper-card-anatomy.svg)
+
+The same shape across every card is what lets synthesis scan the corpus quickly instead of re-reading full papers.
+
+## Skills
+
+- **lit-review** — both literature-review modes described above
+- **manuscript-writing** — IMRAD structure and section templates
+- **paper-review** — the peer-review simulation described above; thin-dispatch with a Claude-bundled fresh-context agent, a Codex agent template, and a Copilot plugin-agent template
+- **manuscript-formatting** — journal-specific formatting (IEEE, Nature, PNAS, Elsevier, LaTeX/BibTeX management) plus revision-response templates
+- **humanizer** — a final natural-writing pass that removes AI-writing tells while preserving meaning and discipline conventions
+
+## Try it
+
+```
+"Review this manuscript at paper.pdf as a peer reviewer"
+"Format my paper for Nature Neuroscience"
+"Start a multi-phase lit review on EEG-based BCIs with strands tools, data, science"
+"Write a single-pass literature review on motor cortex oscillations"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 7, "Manuscript Preparation and Peer Review," and week 5, "Literature Search and Review," cover this plugin hands-on.

--- a/docs/plugins/neuroinformatics.md
+++ b/docs/plugins/neuroinformatics.md
@@ -2,15 +2,17 @@
 
 The `neuroinformatics` plugin covers neuroscience data standards (Brain Imaging Data Structure (BIDS), Hierarchical Event Descriptors (HED)), experiment design (PsychoPy, Lab Streaming Layer (LSL)), and dataset validation.
 
-## Two skills, one defending agent
+## The plugin map
 
 A conversion skill sits at the center; a validator agent defends its output; experiment design covers the data-collection side that happens before conversion:
 
 ![Neuroinformatics plugin map: bids-conversion at the center, defended by the bids-validator agent, with experiment-design covering data collection](../assets/diagrams/neuro-plugin-map.svg)
 
+## Skills
+
 - **bids-conversion** — guided conversion to BIDS for EEG, EMG, MEG, fMRI, and other modalities
-- **bids-validator agent** — autonomous validate-and-fix: runs `bids-validator`, diagnoses errors, and applies corrections
 - **experiment-design** — PsychoPy + LSL experiment scaffolding, feeding BIDS-compatible output back into conversion
+- **bids-validator agent** — autonomous validate-and-fix: runs `bids-validator`, diagnoses errors, and applies corrections
 
 ## One command, six steps, to a validated dataset
 

--- a/docs/plugins/neuroinformatics.md
+++ b/docs/plugins/neuroinformatics.md
@@ -8,24 +8,18 @@ A conversion skill sits at the center; a validator agent defends its output; exp
 
 ![Neuroinformatics plugin map: bids-conversion at the center, defended by the bids-validator agent, with experiment-design covering data collection](../assets/diagrams/neuro-plugin-map.svg)
 
-## Skills
-
-- **bids-conversion** — guided conversion to BIDS for EEG, EMG, MEG, fMRI, and other modalities
-- **experiment-design** — PsychoPy + LSL experiment scaffolding, feeding BIDS-compatible output back into conversion
-- **bids-validator agent** — autonomous validate-and-fix: runs `bids-validator`, diagnoses errors, and applies corrections
-
 ## One command, six steps, to a validated dataset
 
 Converting raw recordings into a shareable BIDS dataset is a fixed sequence:
 
 ![BIDS conversion flow: Inventory, Scaffold, Convert files, JSON sidecars, TSV tables, Validate](../assets/diagrams/bids-conversion-flow.svg)
 
-1. **Inventory** — source data formats, subjects, channels
-2. **Scaffold** — `dataset_description.json`, `participants.tsv`
-3. **Convert files** — BrainVision, EEGLAB `.set`, EDF, BDF, and others
-4. **JSON sidecars** — `SamplingFrequency`, `EEGReference`, and other required metadata
-5. **TSV tables** — channels, events, electrodes
-6. **Validate** — `bids-validator`
+1. **Inventory**: source data formats, subjects, channels
+2. **Scaffold**: `dataset_description.json`, `participants.tsv`
+3. **Convert files**: BrainVision, EEGLAB `.set`, EDF, BDF, and others
+4. **JSON sidecars**: `SamplingFrequency`, `EEGReference`, and other required metadata
+5. **TSV tables**: channels, events, electrodes
+6. **Validate**: `bids-validator`
 
 ## Why the layout is fixed
 
@@ -35,15 +29,21 @@ BIDS's predictable folders and filenames are what let EEGLAB, MNE-Python, `bids-
 
 ![Why BIDS: one predictable layout with machine-readable sidecars lets EEGLAB, MNE-Python, bids-validator, BIDS Apps, OpenNeuro, and NEMAR all read the same data unchanged](../assets/diagrams/bids-why.svg)
 
-A standard structure turns "my data" into "reusable data" — the same folder and filename conventions apply to every BIDS dataset, anywhere, which is what makes cross-dataset tools and mega-analysis pooling possible in the first place.
+A standard structure turns "my data" into "reusable data": the same folder and filename conventions apply to every BIDS dataset, anywhere, which is what makes cross-dataset tools and mega-analysis pooling possible in the first place.
 
 ## HED annotation
 
-HED annotation — tagging events with a standardized, machine-readable vocabulary for the *what* of an event, not just its timing — lives inside the `bids-conversion` and `experiment-design` skills' reference material rather than as a separate skill. Conceptually, going from a plain-English event description to a schema-valid HED tag string is a parse → tag → validate pipeline:
+HED annotation, tagging events with a standardized, machine-readable vocabulary for the *what* of an event, not just its timing, lives inside the `bids-conversion` and `experiment-design` skills' reference material rather than as a separate skill. Conceptually, going from a plain-English event description to a schema-valid HED tag string is a parse → tag → validate pipeline:
 
 ![HEDit pipeline: parse natural language into structured facts, tag by retrieving HED schema nodes, then validate against the official HED validator with feedback looped back into re-tagging](../assets/diagrams/hedit-pipeline.svg)
 
-The HED schema is the contract — nothing in that pipeline invents vocabulary outside it.
+The HED schema is the contract; nothing in that pipeline invents vocabulary outside it.
+
+## Skills
+
+- **bids-conversion**: guided conversion to BIDS for EEG, EMG, MEG, fMRI, and other modalities
+- **experiment-design**: PsychoPy + LSL experiment scaffolding, feeding BIDS-compatible output back into conversion
+- **bids-validator agent**: autonomous validate-and-fix: runs `bids-validator`, diagnoses errors, and applies corrections
 
 ## Try it
 

--- a/docs/plugins/neuroinformatics.md
+++ b/docs/plugins/neuroinformatics.md
@@ -1,0 +1,56 @@
+# Neuroinformatics
+
+The `neuroinformatics` plugin covers neuroscience data standards (Brain Imaging Data Structure (BIDS), Hierarchical Event Descriptors (HED)), experiment design (PsychoPy, Lab Streaming Layer (LSL)), and dataset validation.
+
+## Two skills, one defending agent
+
+A conversion skill sits at the center; a validator agent defends its output; experiment design covers the data-collection side that happens before conversion:
+
+![Neuroinformatics plugin map: bids-conversion at the center, defended by the bids-validator agent, with experiment-design covering data collection](../assets/diagrams/neuro-plugin-map.svg)
+
+- **bids-conversion** — guided conversion to BIDS for EEG, EMG, MEG, fMRI, and other modalities
+- **bids-validator agent** — autonomous validate-and-fix: runs `bids-validator`, diagnoses errors, and applies corrections
+- **experiment-design** — PsychoPy + LSL experiment scaffolding, feeding BIDS-compatible output back into conversion
+
+## One command, six steps, to a validated dataset
+
+Converting raw recordings into a shareable BIDS dataset is a fixed sequence:
+
+![BIDS conversion flow: Inventory, Scaffold, Convert files, JSON sidecars, TSV tables, Validate](../assets/diagrams/bids-conversion-flow.svg)
+
+1. **Inventory** — source data formats, subjects, channels
+2. **Scaffold** — `dataset_description.json`, `participants.tsv`
+3. **Convert files** — BrainVision, EEGLAB `.set`, EDF, BDF, and others
+4. **JSON sidecars** — `SamplingFrequency`, `EEGReference`, and other required metadata
+5. **TSV tables** — channels, events, electrodes
+6. **Validate** — `bids-validator`
+
+## Why the layout is fixed
+
+BIDS's predictable folders and filenames are what let EEGLAB, MNE-Python, `bids-validator`, BIDS Apps, OpenNeuro, and NEMAR all read a dataset without dataset-specific glue code:
+
+![BIDS tree: predictable dataset_description.json, participants.tsv, and per-subject eeg/ folders with .set signals, .json sidecars, and .tsv tables](../assets/diagrams/bids-tree.svg)
+
+![Why BIDS: one predictable layout with machine-readable sidecars lets EEGLAB, MNE-Python, bids-validator, BIDS Apps, OpenNeuro, and NEMAR all read the same data unchanged](../assets/diagrams/bids-why.svg)
+
+A standard structure turns "my data" into "reusable data" — the same folder and filename conventions apply to every BIDS dataset, anywhere, which is what makes cross-dataset tools and mega-analysis pooling possible in the first place.
+
+## HED annotation
+
+HED annotation — tagging events with a standardized, machine-readable vocabulary for the *what* of an event, not just its timing — lives inside the `bids-conversion` and `experiment-design` skills' reference material rather than as a separate skill. Conceptually, going from a plain-English event description to a schema-valid HED tag string is a parse → tag → validate pipeline:
+
+![HEDit pipeline: parse natural language into structured facts, tag by retrieving HED schema nodes, then validate against the official HED validator with feedback looped back into re-tagging](../assets/diagrams/hedit-pipeline.svg)
+
+The HED schema is the contract — nothing in that pipeline invents vocabulary outside it.
+
+## Try it
+
+```
+"Convert ./raw-data to BIDS format, modality EEG, task rest"
+"Validate the BIDS dataset at ./bids-dataset"
+"Design a visual oddball ERP paradigm with 2 conditions"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 9, "Neuroinformatics," covers BIDS, HED, and experiment design hands-on.

--- a/docs/plugins/opencite.md
+++ b/docs/plugins/opencite.md
@@ -8,24 +8,24 @@ The `opencite` plugin searches academic literature, explores citation graphs, do
 
 ![Opencite search strategies: query for canonical high-citation search, recent/specific search, and citation-graph traversal](../assets/diagrams/opencite-strategies.svg)
 
-- **Query** — canonical, high-citation search for foundational papers on a topic
-- **Recent / specific** — targeted search for a known paper or a narrow, recent result
-- **Cite graph** — traversal of citation links (what cites this, what this cites)
+- **Query**: canonical, high-citation search for foundational papers on a topic
+- **Recent / specific**: targeted search for a known paper or a narrow, recent result
+- **Cite graph**: traversal of citation links (what cites this, what this cites)
 
 ## Batch fetch, two parallel output trees
 
-A batch fetch-and-convert run always produces two parallel structures — one for PDFs, one for markdown — because PDFs are sometimes paywalled but a markdown conversion from abstract/metadata is always available:
+A batch fetch-and-convert run always produces two parallel structures, one for PDFs, one for markdown, because PDFs are sometimes paywalled but a markdown conversion from abstract/metadata is always available:
 
 ![Opencite output tree: papers/pdf/ (open or paywall per file) and papers/markdown/ (always present) plus img/ for figures](../assets/diagrams/opencite-output-tree.svg)
 
-- **Open** badge — the PDF was retrieved successfully and stored under `pdf/`
-- **Paywall** badge — the PDF was blocked; a markdown conversion was still made from the abstract/metadata
+- **Open** badge: the PDF was retrieved successfully and stored under `pdf/`
+- **Paywall** badge: the PDF was blocked; a markdown conversion was still made from the abstract/metadata
 
 This is also the corpus format that `manuscript:lit-review`'s multi-phase mode builds paper-cards from.
 
 ## Skills
 
-- **opencite** — literature search across the aggregated sources above, citation-graph exploration, PDF download, PDF-to-markdown conversion, and BibTeX export
+- **opencite**: literature search across the aggregated sources above, citation-graph exploration, PDF download, PDF-to-markdown conversion, and BibTeX export
 
 ## Try it
 
@@ -40,4 +40,4 @@ This is also the corpus format that `manuscript:lit-review`'s multi-phase mode b
 The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 5, "Literature Search and Review," covers this plugin hands-on.
 
 !!! note
-    The `opencite` plugin here is a snapshot of the standalone [`neuromechanist/opencite`](https://github.com/neuromechanist/opencite) plugin. If you've already installed that standalone plugin, don't install it again from this marketplace — having both installed creates duplicate skills.
+    The `opencite` plugin here is a snapshot of the standalone [`neuromechanist/opencite`](https://github.com/neuromechanist/opencite) plugin. If you've already installed that standalone plugin, don't install it again from this marketplace; having both installed creates duplicate skills.

--- a/docs/plugins/opencite.md
+++ b/docs/plugins/opencite.md
@@ -1,0 +1,43 @@
+# Opencite
+
+The `opencite` plugin searches academic literature, explores citation graphs, downloads PDFs, and exports BibTeX. It wraps the [`opencite`](https://github.com/neuromechanist/opencite) CLI, aggregating Semantic Scholar, OpenAlex, PubMed, arXiv, and bioRxiv into one interface.
+
+## Three search strategies
+
+`opencite` picks a search strategy based on what you're actually looking for:
+
+![Opencite search strategies: query for canonical high-citation search, recent/specific search, and citation-graph traversal](../assets/diagrams/opencite-strategies.svg)
+
+- **Query** — canonical, high-citation search for foundational papers on a topic
+- **Recent / specific** — targeted search for a known paper or a narrow, recent result
+- **Cite graph** — traversal of citation links (what cites this, what this cites)
+
+## Batch fetch, two parallel output trees
+
+A batch fetch-and-convert run always produces two parallel structures — one for PDFs, one for markdown — because PDFs are sometimes paywalled but a markdown conversion from abstract/metadata is always available:
+
+![Opencite output tree: papers/pdf/ (open or paywall per file) and papers/markdown/ (always present) plus img/ for figures](../assets/diagrams/opencite-output-tree.svg)
+
+- **Open** badge — the PDF was retrieved successfully and stored under `pdf/`
+- **Paywall** badge — the PDF was blocked; a markdown conversion was still made from the abstract/metadata
+
+This is also the corpus format that `manuscript:lit-review`'s multi-phase mode builds paper-cards from.
+
+## Skills
+
+- **opencite** — literature search across the aggregated sources above, citation-graph exploration, PDF download, PDF-to-markdown conversion, and BibTeX export
+
+## Try it
+
+```
+"Find the top 10 most cited papers on brain-computer interfaces"
+"Look up DOI 10.1038/nature12373 and download the PDF"
+"Convert this PDF to markdown"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 5, "Literature Search and Review," covers this plugin hands-on.
+
+!!! note
+    The `opencite` plugin here is a snapshot of the standalone [`neuromechanist/opencite`](https://github.com/neuromechanist/opencite) plugin. If you've already installed that standalone plugin, don't install it again from this marketplace — having both installed creates duplicate skills.

--- a/docs/plugins/presentation.md
+++ b/docs/plugins/presentation.md
@@ -1,0 +1,20 @@
+# Presentation
+
+The `presentation` plugin creates interactive Reveal.js presentations from a JSON spec, using the [Agentic Presentation Builder](https://github.com/neuromechanist/agentic-presentation-builder) engine. It supports 7 element types (text, bullets, images, Mermaid diagrams, callouts, code blocks, tables), 5 themes, animated progressive reveals, speaker notes, and LaTeX math.
+
+The skill teaches the agent the JSON schema and authoring workflow; the builder repo handles rendering, so you describe the deck and the skill produces a spec the builder can render, present, or export.
+
+## Skills
+
+- **presentation-builder** — JSON-schema authoring for Reveal.js decks: slide structure, element types, themes, progressive reveals, speaker notes, and math
+
+## Try it
+
+```
+"Create a 10-slide academic presentation on EEG signal processing"
+"Build a conference talk on brain-computer interfaces"
+```
+
+## Learn more
+
+There's no dedicated course week for `presentation-builder` — instead, the [Agentic Research Course](https://courses.osc.earth/agentic-research/) itself is built with it. Every slide deck across all ten weeks of the course is a `presentation-builder` JSON spec rendered through the same engine this plugin ships, so the course site is itself a working example of the plugin end to end.

--- a/docs/plugins/presentation.md
+++ b/docs/plugins/presentation.md
@@ -6,7 +6,7 @@ The skill teaches the agent the JSON schema and authoring workflow; the builder 
 
 ## Skills
 
-- **presentation-builder** — JSON-schema authoring for Reveal.js decks: slide structure, element types, themes, progressive reveals, speaker notes, and math
+- **presentation-builder**: JSON-schema authoring for Reveal.js decks: slide structure, element types, themes, progressive reveals, speaker notes, and math
 
 ## Try it
 
@@ -17,4 +17,4 @@ The skill teaches the agent the JSON schema and authoring workflow; the builder 
 
 ## Learn more
 
-There's no dedicated course week for `presentation-builder` — instead, the [Agentic Research Course](https://courses.osc.earth/agentic-research/) itself is built with it. Every slide deck across all ten weeks of the course is a `presentation-builder` JSON spec rendered through the same engine this plugin ships, so the course site is itself a working example of the plugin end to end.
+There's no dedicated course week for `presentation-builder`; instead, the [Agentic Research Course](https://courses.osc.earth/agentic-research/) itself is built with it. Every slide deck across all ten weeks of the course is a `presentation-builder` JSON spec rendered through the same engine this plugin ships, so the course site is itself a working example of the plugin end to end.

--- a/docs/plugins/project.md
+++ b/docs/plugins/project.md
@@ -1,0 +1,53 @@
+# Project
+
+The `project` plugin is the marketplace's development-lifecycle toolkit: initialization, epic/sprint workflow, PR review, CI/CD scaffolding, and a set of core engineering-workflow skills (onboarding, planning, the day-to-day change loop, debugging, and multi-agent orchestration).
+
+## Epics, phases, and worktrees
+
+Complex, multi-phase features are epics: one epic issue, broken into phase sub-issues, each developed in its own git worktree so phases can run in parallel without stepping on each other's working tree.
+
+![Epic branching: main branches to an epic branch, which branches into phases P1 through P6, which integrate back into the epic branch before merging to main](../assets/diagrams/epic-branching.svg)
+
+Each phase gets its own worktree, checked out from the epic branch, so you can have several phases in progress on disk at once:
+
+![Worktree layout: main, epic-hbn, and per-phase feature worktrees (feature/epic-hbn-phase1, feature/epic-hbn-phase2) checked out side by side](../assets/diagrams/worktree.svg)
+
+The same epic → sub-issue → worktree shape generalizes beyond code changes. `epic-dev` is the entry point other skills delegate to when they need git-tracked, parallelizable phase decomposition — for example, `manuscript:lit-review`'s multi-phase mode delegates strand orchestration (one strand per literature-review theme, each with its own sub-issue, worktree, and collection folder) to `project:epic-dev`:
+
+![Strand fan-out: one epic issue decomposed into four strand sub-issues, each with its own collection folder and acceptance criteria](../assets/diagrams/strand-fanout.svg)
+
+`workflow-reference` documents the branch, state-file, worktree, and GitHub command conventions this pattern relies on.
+
+## Skills
+
+- **init-project** — scaffold new projects with `AGENTS.md`, a Claude Code `CLAUDE.md` import wrapper, `.rules/`, `.context/`, and config files
+- **update-rules** — non-destructive sync of `AGENTS.md`, the `CLAUDE.md` adapter, and `.rules/` against the latest templates at user or project level
+- **epic-dev** — the multi-phase feature workflow described above: git worktrees, GitHub issues, and phased PR delivery
+- **workflow-reference** — branch, state-file, worktree, and GitHub command reference for epic/sprint workflows
+- **pr-review-toolkit** — PR and recent-change review across code quality, tests, error handling, comments/docs, type design, and simplification
+- **codebase-onboarding** — verified reconnaissance of an unfamiliar codebase or research field before planning or editing: a fixed bootstrap sequence, parallel read-only explorer fan-out, and a report contract separating verified facts from assumptions
+- **implementation-planning** — plans a weaker model could execute: two registers by stakes, pre-registered decision gates, load-bearing-claim verification, and a mandatory open-judgment-calls list
+- **engineering-loop** — the single-PR change workflow: mirror an existing pattern, pin tests first for refactors, per-commit gates against a measured baseline, review with all findings addressed or rejected with reasons
+- **debugging** — reproduce-isolate-prove-fix-verify with anti-shortcut gates (never weaken tests or guardrails, no silent fallbacks)
+- **agent-fanout** — orchestrating subagents and teammates within a session: spawning/messaging mechanics, a role taxonomy with worker-tier model routing, full-lifecycle briefing templates, and a hard cap of 40 agents per run computed before launch. This is a different pattern from the epic/worktree fan-out above — it's in-session delegation, not a git-tracked multi-phase workflow.
+- **ci-scaffolding** — generate GitHub Actions workflows for Python (ruff + pytest) or TypeScript (biome + bun test)
+- **docker-packaging** — multi-stage Dockerfiles with uv/bun, health checks, and security hardening
+- **security-audit** — credential scanning, dependency audit, OWASP checklist, configuration hardening
+- **document-processing** — PDF/image OCR, text extraction, markdown conversion
+
+Includes autonomous agents: **dependency-auditor** (vulnerability scanning), **release-prep** (pre-release validation), and a Claude-bundled **pr-review-toolkit** reviewer.
+
+## Try it
+
+```
+/init-project "Python EEG analysis package"
+/update-rules project
+/epic-dev "build a community dashboard"
+/release-prep --minor
+"Set up CI for this Python project with ruff and pytest"
+"Process scanned-document.pdf and convert to markdown"
+```
+
+## Learn more
+
+The [Agentic Research Course](https://courses.osc.earth/agentic-research/) week 3, "Project Management with AI," covers epics, sprints, and worktrees hands-on.

--- a/docs/plugins/project.md
+++ b/docs/plugins/project.md
@@ -12,7 +12,7 @@ Each phase gets its own worktree, checked out from the epic branch, so you can h
 
 ![Worktree layout: main, epic-hbn, and per-phase feature worktrees (feature/epic-hbn-phase1, feature/epic-hbn-phase2) checked out side by side](../assets/diagrams/worktree.svg)
 
-The same epic → sub-issue → worktree shape generalizes beyond code changes. `epic-dev` is the entry point other skills delegate to when they need git-tracked, parallelizable phase decomposition — for example, `manuscript:lit-review`'s multi-phase mode delegates strand orchestration (one strand per literature-review theme, each with its own sub-issue, worktree, and collection folder) to `project:epic-dev`:
+The same epic → sub-issue → worktree shape generalizes beyond code changes. `epic-dev` is the entry point other skills delegate to when they need git-tracked, parallelizable phase decomposition. For example, `manuscript:lit-review`'s multi-phase mode delegates strand orchestration (one strand per literature-review theme, each with its own sub-issue, worktree, and collection folder) to `project:epic-dev`:
 
 ![Strand fan-out: one epic issue decomposed into four strand sub-issues, each with its own collection folder and acceptance criteria](../assets/diagrams/strand-fanout.svg)
 
@@ -20,20 +20,20 @@ The same epic → sub-issue → worktree shape generalizes beyond code changes. 
 
 ## Skills
 
-- **init-project** — scaffold new projects with `AGENTS.md`, a Claude Code `CLAUDE.md` import wrapper, `.rules/`, `.context/`, and config files
-- **update-rules** — non-destructive sync of `AGENTS.md`, the `CLAUDE.md` adapter, and `.rules/` against the latest templates at user or project level
-- **epic-dev** — the multi-phase feature workflow described above: git worktrees, GitHub issues, and phased PR delivery
-- **workflow-reference** — branch, state-file, worktree, and GitHub command reference for epic/sprint workflows
-- **pr-review-toolkit** — PR and recent-change review across code quality, tests, error handling, comments/docs, type design, and simplification
-- **codebase-onboarding** — verified reconnaissance of an unfamiliar codebase or research field before planning or editing: a fixed bootstrap sequence, parallel read-only explorer fan-out, and a report contract separating verified facts from assumptions
-- **implementation-planning** — plans a weaker model could execute: two registers by stakes, pre-registered decision gates, load-bearing-claim verification, and a mandatory open-judgment-calls list
-- **engineering-loop** — the single-PR change workflow: mirror an existing pattern, pin tests first for refactors, per-commit gates against a measured baseline, review with all findings addressed or rejected with reasons
-- **debugging** — reproduce-isolate-prove-fix-verify with anti-shortcut gates (never weaken tests or guardrails, no silent fallbacks)
-- **agent-fanout** — orchestrating subagents and teammates within a session: spawning/messaging mechanics, a role taxonomy with worker-tier model routing, full-lifecycle briefing templates, and a hard cap of 40 agents per run computed before launch. This is a different pattern from the epic/worktree fan-out above — it's in-session delegation, not a git-tracked multi-phase workflow.
-- **ci-scaffolding** — generate GitHub Actions workflows for Python (ruff + pytest) or TypeScript (biome + bun test)
-- **docker-packaging** — multi-stage Dockerfiles with uv/bun, health checks, and security hardening
-- **security-audit** — credential scanning, dependency audit, OWASP checklist, configuration hardening
-- **document-processing** — PDF/image OCR, text extraction, markdown conversion
+- **init-project**: scaffold new projects with `AGENTS.md`, a Claude Code `CLAUDE.md` import wrapper, `.rules/`, `.context/`, and config files
+- **update-rules**: non-destructive sync of `AGENTS.md`, the `CLAUDE.md` adapter, and `.rules/` against the latest templates at user or project level
+- **epic-dev**: the multi-phase feature workflow described above: git worktrees, GitHub issues, and phased PR delivery
+- **workflow-reference**: branch, state-file, worktree, and GitHub command reference for epic/sprint workflows
+- **pr-review-toolkit**: PR and recent-change review across code quality, tests, error handling, comments/docs, type design, and simplification
+- **codebase-onboarding**: verified reconnaissance of an unfamiliar codebase or research field before planning or editing: a fixed bootstrap sequence, parallel read-only explorer fan-out, and a report contract separating verified facts from assumptions
+- **implementation-planning**: plans a weaker model could execute: two registers by stakes, pre-registered decision gates, load-bearing-claim verification, and a mandatory open-judgment-calls list
+- **engineering-loop**: the single-PR change workflow: mirror an existing pattern, pin tests first for refactors, per-commit gates against a measured baseline, review with all findings addressed or rejected with reasons
+- **debugging**: reproduce-isolate-prove-fix-verify with anti-shortcut gates (never weaken tests or guardrails, no silent fallbacks)
+- **agent-fanout**: orchestrating subagents and teammates within a session: spawning/messaging mechanics, a role taxonomy with worker-tier model routing, full-lifecycle briefing templates, and a hard cap of 40 agents per run computed before launch. This is a different pattern from the epic/worktree fan-out above; it's in-session delegation, not a git-tracked multi-phase workflow.
+- **ci-scaffolding**: generate GitHub Actions workflows for Python (ruff + pytest) or TypeScript (biome + bun test)
+- **docker-packaging**: multi-stage Dockerfiles with uv/bun, health checks, and security hardening
+- **security-audit**: credential scanning, dependency audit, OWASP checklist, configuration hardening
+- **document-processing**: PDF/image OCR, text extraction, markdown conversion
 
 Includes autonomous agents: **dependency-auditor** (vulnerability scanning), **release-prep** (pre-release validation), and a Claude-bundled **pr-review-toolkit** reviewer.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,5 @@
+:root > * {
+  --md-primary-fg-color:        #6B3FA0;
+  --md-primary-fg-color--light: #6B3FA0;
+  --md-primary-fg-color--dark:  #ECE5F7;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+site_name: Research Skills
+site_description: Cross-agent plugin marketplace for academic research workflows and development tooling
+site_author: Seyed (Yahya) Shirazi
+site_url: https://neuromechanist.github.io/research-skills/
+repo_url: https://github.com/neuromechanist/research-skills
+repo_name: neuromechanist/research-skills
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - navigation.indexes
+    - content.code.copy
+    - content.code.annotate
+
+extra_css:
+  - stylesheets/extra.css
+
+plugins:
+  - search:
+      lang: en
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - footnotes
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Plugins:
+      - Project: plugins/project.md
+      - Grant: plugins/grant.md
+      - Manuscript: plugins/manuscript.md
+      - Opencite: plugins/opencite.md
+      - Figures: plugins/figures.md
+      - Presentation: plugins/presentation.md
+      - Neuroinformatics: plugins/neuroinformatics.md
+  - Cross-Agent Compatibility: cross-agent-compatibility.md
+  - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "research-skills"
+version = "0.1.0"
+description = "Tooling project for the research-skills marketplace docs site (not a distributed Python package)"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.uv]
+package = false
+
+[dependency-groups]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "pymdown-extensions>=10.10.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,541 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/56/10a88e00039537d74bd420f0457c52ab8f58a1af56126e3b9f1b1c8c4724/charset_normalizer-3.4.8.tar.gz", hash = "sha256:d9bf144d6faf12c70d58e47f7512992ae2882b820031d6cef68152deb645bf2d", size = 151790, upload-time = "2026-07-06T15:27:58.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b5/7f10929c45e2d0d0dc78bead98458c271af3e028e66b16441de88829a8b7/charset_normalizer-3.4.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca832d525a2a52542048111cb44e0dea595b9ad53ad542020aa770f308427b92", size = 316812, upload-time = "2026-07-06T15:25:58.71Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b4/8e936a5e19d7e7b19db29aeed0988b481dc745eed3437829780f6ec98ce9/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab07eb7b564635602734c3ef0e8d2db9d59cbbce54f5dc42b8f11aa1f56ce364", size = 213580, upload-time = "2026-07-06T15:26:00.121Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b8/dbc3b3c4796e4e29e193c5d7e100bb8ebfa66267994c01ba1eaaa3ebc474/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e88da593ea098194ea08f58924b716a9ae0c39058edad8c5c9b0bafa39fbd56", size = 235244, upload-time = "2026-07-06T15:26:01.402Z" },
+    { url = "https://files.pythonhosted.org/packages/93/22/808ff7eb8d344a174b89a388a4540fb86e486f608c16b9a2a023ddf6c9c6/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ca83574f63f71b485da1c50d4e17bcef7375a56b459a861562554f1fbaac1a4", size = 229678, upload-time = "2026-07-06T15:26:02.62Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/35/525d3e86af55a66073c02dbf9b6a720c74601489e4b4cb391cad0a4cb620/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9840cca6969a7e35498f1ce6fc32b7842500783d303b5ab254679a0f591093c4", size = 221015, upload-time = "2026-07-06T15:26:03.888Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/63/10f18541380f2d1c40ffda42835661aa9f88a1333e586d7b0f1d29869113/charset_normalizer-3.4.8-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:ca8776b012d464136c239f51133120db94397bc69f3faee404ff8c99827f8192", size = 205002, upload-time = "2026-07-06T15:26:05.32Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/28168f20737bb7d7d40d29cb82d2084cb3a8c19a4e1fef18f07069a24338/charset_normalizer-3.4.8-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:23c40d25fe581d34ff0ef7ff1ca1527f5c51c5c6edf0b8384eeafac4a0438469", size = 217527, upload-time = "2026-07-06T15:26:06.47Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/41/bc39417675dcca7151be665ec20f4b1b25ff3486d8eb2f3d7662ebc56082/charset_normalizer-3.4.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6809e40a8876eb4742676fbbb57056c0344ef2555e5597d4343f0b365953afdd", size = 216538, upload-time = "2026-07-06T15:26:07.836Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7f/e322a4f060a32aa9510d3c76689be7d58c62653b09fe156912471e17a7bc/charset_normalizer-3.4.8-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1bfd4bf262d6f26805cc6a32dae2554db66ef7533e6c62cc12644d3882be05e5", size = 206170, upload-time = "2026-07-06T15:26:09.269Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/64/07d0a02c401433ba18d57f55a96ffe7c701a11eac57c74bae0e1506cfa40/charset_normalizer-3.4.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9421549d803f0f712aa6e1496d15ff5ac510fc4c7104e7e299ea1d498d582d59", size = 222807, upload-time = "2026-07-06T15:26:10.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/84/2d132bdad9cadc3251bbad2813d29642c068855ad0394234f76845672100/charset_normalizer-3.4.8-cp311-cp311-win32.whl", hash = "sha256:9a2748f7588b0c1e5166db3a9448fe86e392479aded89b0c86382d41cade91a2", size = 150195, upload-time = "2026-07-06T15:26:11.654Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5f/c46567479049f46929d8ed9e628990c2419f369c5ea5797add417808d37b/charset_normalizer-3.4.8-cp311-cp311-win_amd64.whl", hash = "sha256:2e9f0db12ea28a3349e514443fc56d4b1fb3c81d0f9c0e33dacfdfc2ac63f774", size = 161151, upload-time = "2026-07-06T15:26:13.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ac/39a8bc03f7550f86f8c43205f2c97bc3a4cea775e5a0c0317917679cdef5/charset_normalizer-3.4.8-cp311-cp311-win_arm64.whl", hash = "sha256:4b1f25c6e376033f31463d66f8bb01ae77a128ca11c6677c69ed8e9ce913bbf9", size = 152392, upload-time = "2026-07-06T15:26:14.335Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/39de60ef5687662f467bed3d1e6944c67a4f0d057141d0404002b8f405ae/charset_normalizer-3.4.8-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:faac37c4904598daa00cb4c9b32f3b4cc814fb5f145d7a531ceb4a70f2114132", size = 319040, upload-time = "2026-07-06T15:26:15.854Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/a9474c3aeaa337c8a330c0dc5df266527d56da3b189c029529f6b08af2a4/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f191c19a32dc6cec0fb8079789d786254653a9ce906fcab04ccd2eed07bba233", size = 215541, upload-time = "2026-07-06T15:26:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a9/be1ff7e81f6e086dced2a7a7a28b789be351d9796084ccaf6136a4ffafb3/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05811b76943d477bb90822dedb5c4565cef70148847a59d574e2b35043aeb563", size = 236913, upload-time = "2026-07-06T15:26:18.482Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/d8c5eae93da26d463f9ebe46a4937ca44434dc2937a565b92437befb3d94/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3868a3e4ec1e40b419e060d063f93eac6f046fa21426c4816421223ae7dc8ab8", size = 232815, upload-time = "2026-07-06T15:26:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/98e301ca944bcca5e6bc312406b579c8a6d81546c1b494afb3a9478495d6/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25f93d194eb6264c64416cabff46a91f6d99b97e7525a1b4f35c77a99e75cc68", size = 223995, upload-time = "2026-07-06T15:26:20.931Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/df/f5222366b76dcb31453a9bd922610c893540d0e729fd390439b0d3e972ee/charset_normalizer-3.4.8-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:ee6a62492f18d432cca031fabd158f400a8c25bf7b9458f50953393a2a23d97a", size = 208522, upload-time = "2026-07-06T15:26:22.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/52/293220d59d8ddfb8aa56836b33bd6df58e70795d8a102a858c2984480f00/charset_normalizer-3.4.8-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c16cb4fc35e4b064f5ee78d849f15a550ada1729c3372916672e38f1f01d1d4", size = 219660, upload-time = "2026-07-06T15:26:23.493Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2c/81a298e66f3d01e61bfc6f7064bbb553b067a9f1d979e5962bf00733069b/charset_normalizer-3.4.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2fbd0edb0426ab28e70fac9d1d4ef549eb5a64a2521f0428c441d75e4387e6c2", size = 218230, upload-time = "2026-07-06T15:26:24.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/45/f1dd2328cbc3340705f82072c09bd4c68d6e079191cde05810c1eac77eee/charset_normalizer-3.4.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ccb9052771216170015f810b88065fd9e13b1e0b391f92abb9b47e0919a42aad", size = 210006, upload-time = "2026-07-06T15:26:25.837Z" },
+    { url = "https://files.pythonhosted.org/packages/38/63/28697000620e117eb413424caaf60b6f98ddb1b09b2c11f7c0038d9936a7/charset_normalizer-3.4.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3809ba5d3cd02aca0894597f2669a825bdfe2229061515c128b0f4e5533b4ab5", size = 225771, upload-time = "2026-07-06T15:26:27.079Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a7/d5844e315f5f35e7938c415f07a1df144eed1cf993f1b43cc16c980c5b46/charset_normalizer-3.4.8-cp312-cp312-win32.whl", hash = "sha256:de63c31666a049f653ada24e800192e3c019e96bc7d70fb449a000bccf26a36f", size = 150922, upload-time = "2026-07-06T15:26:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/82/eb8b72f184b1e4986dd9daec15d7f6d9285a6728d2b07b7f04656829f473/charset_normalizer-3.4.8-cp312-cp312-win_amd64.whl", hash = "sha256:14a4bbe066f3fb05c6ba70e9cf9d34614b57a2fd70ea8c27cc30f34155e16a58", size = 162294, upload-time = "2026-07-06T15:26:29.745Z" },
+    { url = "https://files.pythonhosted.org/packages/09/5a/ab810134aa41034a08ffe94c058102016e6ad9bce62f3cdba547b4723385/charset_normalizer-3.4.8-cp312-cp312-win_arm64.whl", hash = "sha256:2b5b0c0dca0a02c3f816f89abf18af3d20416dedbc3d3aa5f3981045f88ae7b0", size = 152409, upload-time = "2026-07-06T15:26:31.034Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/fe5a8572a70cd9cba79f80af9388ac8c5c914ed4459b956f940244e499a5/charset_normalizer-3.4.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:057f8609f7341618c98e5aa9a6109fa116acff2a658497d47ab3325b5e8f2b08", size = 317424, upload-time = "2026-07-06T15:26:32.23Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/d71c96616b6825425a876f79f38fa440db30b32cc1166179a839f6259150/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c591f9a82adc5b89a039b90df74e43de2b9177fb46771172bed7b80722a70db0", size = 214723, upload-time = "2026-07-06T15:26:33.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/35/dc9eeb297f19b7b6ada39709ccb74937e6c51f0947958ae601a977cedd5d/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5b56f449132d9adefe55b87635d05177a914ed5d070438a74725e1d77a280002", size = 236200, upload-time = "2026-07-06T15:26:34.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/37/6775fe852b4acad8bf7e0575fbe8aa9f41b546e33251acbded3c04a6b0d9/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1004c3b5831a301dadfb9e916f38e78e2ff3e08db24a1ad7c354db8ee3dea9c3", size = 231740, upload-time = "2026-07-06T15:26:36.498Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/28/1bcc3f5f3bac81532384adcfcdd9362c7f46a188a19deacc1ddaf7bdaa00/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60883e22821d17c9e5b4f3ca1ef8074f766e3db28791f851b665929c515635c0", size = 222888, upload-time = "2026-07-06T15:26:38.161Z" },
+    { url = "https://files.pythonhosted.org/packages/47/81/9f3993ca62ef090c58059da641e49e3129e74700a6a3beb58436cdb8d4b9/charset_normalizer-3.4.8-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:21e4dbb942c8a6342e2685f232dd2a7bc73465697bd26ead4f118271d28be383", size = 207649, upload-time = "2026-07-06T15:26:39.628Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f4/679f636bcbdc2d53d06b1f4039be310450dca95a9f76bbf22f09985556e8/charset_normalizer-3.4.8-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84bcae14c65e645ca66b661339183d32b8c846a17c96e3e81ab3d346e1c498d4", size = 218908, upload-time = "2026-07-06T15:26:40.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/44/96e8c81867ba8a45ff893c8e7474c2d6b9633f7aa663da7901d040214d3e/charset_normalizer-3.4.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b4e4d44b8287aa13a25e16e29393d494b0643b24894f7c8266c6f6788dd36337", size = 217096, upload-time = "2026-07-06T15:26:42.148Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bf/4d53f04f29bdb22601701f4f9f4d038edfb27976c296fcb7400c02736a6e/charset_normalizer-3.4.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:f68545d1b267dbfafd5d253b6d1cb161562c4e61ab25b5c4cdb7d9e5923e441e", size = 209355, upload-time = "2026-07-06T15:26:43.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/60/92b3f630798d777fa880ad289a3f9f2fc663e4b4beb24783c53318820254/charset_normalizer-3.4.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1936e48214adea74922a20c8ab41b1393ae27cc9e329eb1f0b937d3416824f36", size = 224732, upload-time = "2026-07-06T15:26:44.892Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/85/eafa0a3c7bb6fe9f02f4c7901f02071933cac85ee634197e17280818c6de/charset_normalizer-3.4.8-cp313-cp313-win32.whl", hash = "sha256:1f8e3521860187d597f3867d8466da225b9179ea2833bb26de1bb026144d07c3", size = 150358, upload-time = "2026-07-06T15:26:46.153Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8c/879fafff7b47bb1166d289f2d2472cb31b9922f9f4ca1f392edf85ec16be/charset_normalizer-3.4.8-cp313-cp313-win_amd64.whl", hash = "sha256:8b654b6f52a0a9a6be38e88f3e1dc68f1093ebeb2abbadafc7c82da0786a34be", size = 161685, upload-time = "2026-07-06T15:26:47.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/46/b57c7e778a7b578f28d35fd38544687d4f8d9c019585eebc5ad936073fad/charset_normalizer-3.4.8-cp313-cp313-win_arm64.whl", hash = "sha256:d2d5a250ee26e29468b7607d97479221b069fa8aaf6f929ac84ec0e962e15154", size = 152333, upload-time = "2026-07-06T15:26:48.689Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bc/0a8540b8cd494951cca1428606373942803f5ffcec40fe798f819c5a8adb/charset_normalizer-3.4.8-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:77e993ecf65f21ab1f82266ff5e84a7de2c879e7d9b8bc006009df83f22a1d5e", size = 316993, upload-time = "2026-07-06T15:26:49.962Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/99/a0868f0a1f0a045fd374d1f2cf7042d8ad5d7fb4dd1f4ac7365e319f7e32/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:524939917f17f6de502dfda30b472550965740d7f126659d4c4f8dd1569cce22", size = 215638, upload-time = "2026-07-06T15:26:51.338Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/43c4d09a09b5557cc5fe1d87c9d96f86a3942aec0517d2b5408cef87ca75/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a4508989ba8e2ce43ef989453d18188b261546e8188cbdd4ef451fb9e4c3b467", size = 236456, upload-time = "2026-07-06T15:26:52.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/67/492ca98b3ab785b736b5da10c1bc233e1c8fec6c0cdb29b482c38bfc52a2/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9e44127f7d11eee4548ad2cdf1f4e1b6eaaddd5cb92d15ad65f6ecc9bcf403ab", size = 232253, upload-time = "2026-07-06T15:26:53.838Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/1e6eff58c14f1aace1e26d80defbeaea2d35e075dbe4b611111ee4b47fa8/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb90317359f7e67bb6df615999a95e0980877468e617ddce8b6c2f8e7fe60d95", size = 222886, upload-time = "2026-07-06T15:26:55.009Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7a/90056a5326b0c4b9a3f924d337729c344c11542e5bc7191e50410db61587/charset_normalizer-3.4.8-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:35d9e7a9c960520ae89d1f4e305d1c047a74dea2e0f73a0e84f879356c2e8776", size = 206482, upload-time = "2026-07-06T15:26:56.306Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/94761d31a33878dbb5008ddbd918615061fcf5c0a612aa3075450e60f628/charset_normalizer-3.4.8-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:92e322b054c7ff886f78feab7360736bb45de2e18cf4a0ee84e8fc5a08d53a19", size = 218929, upload-time = "2026-07-06T15:26:57.422Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/00b9675acd7c4b926b9102ee3f0d1a570ce943901be73b87485001393fe1/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c0086d97094363556206dc3bcf43f7edcfc043ea7a568a46f45efea74858bd1", size = 218069, upload-time = "2026-07-06T15:26:58.719Z" },
+    { url = "https://files.pythonhosted.org/packages/04/11/94ada5a0482ee4bf688d04be4c7d6fd945d37370d04a95671040dfe2b416/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0752c849b51198267df2aba013c4de3a2955bd014a4fd70828809946c1acbc0c", size = 207146, upload-time = "2026-07-06T15:27:00.058Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f7/246bd36762207ab4752cd436b64e5d81a1668b15ddea7b5b2d0e8545e727/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2a4707e09eca11e81ece4fced600c5a0a801f568b962244f6f517bc274745fc9", size = 224896, upload-time = "2026-07-06T15:27:01.599Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f7/3510622d1fbe13b0ebf827c475e40a27e2be427140d792878b63ab6425cc/charset_normalizer-3.4.8-cp314-cp314-win32.whl", hash = "sha256:8ea67f427c073ae3da0923aa55f3715131fa613a61a7f2f8d762bde75eaf00ae", size = 150851, upload-time = "2026-07-06T15:27:02.964Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2b/9ce65dd21672b55cf800cca5f4433afa1586fda1d78731067ec9ec544c62/charset_normalizer-3.4.8-cp314-cp314-win_amd64.whl", hash = "sha256:ff71018850863362e5c7533769d0a9f77715c31af1502d523630ce822922f5c9", size = 162549, upload-time = "2026-07-06T15:27:04.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/34/9a5967eed666a88f31a0866884606d9ec3c2cd6091e2ccd7e0b4c4176c35/charset_normalizer-3.4.8-cp314-cp314-win_arm64.whl", hash = "sha256:44464e66f4da2f21dea7145c7693f9f60717ca4794a954dea5bf8c2c932678bd", size = 153079, upload-time = "2026-07-06T15:27:05.608Z" },
+    { url = "https://files.pythonhosted.org/packages/02/4f/aa44cc81d8987f105352c74c0bf919007f8b80e9880d28bcf0393c1a816e/charset_normalizer-3.4.8-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50a0c2e58ad2c203adb616fef28941b7e13716adbc25e0dfaeec29f5afe6382f", size = 338586, upload-time = "2026-07-06T15:27:06.86Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2b/b0392e2b235c08ff0623d905c2ee8ac820620544043c1ce92ce0b3d64c55/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a1e589fdb95c76f08288bbb346230cdd8994db74903db6637b380f7b5fc9336", size = 222764, upload-time = "2026-07-06T15:27:08.23Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a1/7d466879190731f5559662c22232646f2ae2dace2323c3e5aefcf78d458a/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3d7c887444c5a7ef0d68d358d81e758a850bc626f8e639e2ca5667153272b20", size = 241331, upload-time = "2026-07-06T15:27:09.512Z" },
+    { url = "https://files.pythonhosted.org/packages/70/17/8b89e797137aa28c8fb0bafbafc243246a7afe21620a13b00e37624ece1d/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:65c389b96c0cfff3a3f0458fa1c7ce554a30e23101a88a49f03997afce6a929f", size = 239323, upload-time = "2026-07-06T15:27:10.86Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/98/1c1940730ed22d50983be4e243c722c89d5136d6f073bd840d1128bfddcb/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:593403fc47dcdf55e2987b2e3cc2e064127e2b908929f1f18b2e4a4652cbd780", size = 229964, upload-time = "2026-07-06T15:27:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/53/2d/bb8e81b7ff603d3f77e9a8a5d1ad34fcabbf3c54d300c29d99fba581fa23/charset_normalizer-3.4.8-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:606088e9fa2b7469ab9c42d4da8e05a415622a07714edd2fcd8fed48dda4c853", size = 212405, upload-time = "2026-07-06T15:27:13.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1f/e52a3a53b13da591bb8f21d29e63877268eadf20686b7762351d4b89062c/charset_normalizer-3.4.8-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0317406326fed512f42a1632ad91a96228a7616c06547666a6dd79967f1bd6ca", size = 226918, upload-time = "2026-07-06T15:27:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f9/32996d79c57189af9722fe618f46d8a86b7be035ca98887b8d0c3821f141/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b67d50ee47e5c57a0064a9cb575b963a7125819dfd1fd094d44d378fff94659b", size = 225113, upload-time = "2026-07-06T15:27:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d2/9248c18e695696513774523a794cfb8b677521ce9ad7554d301cb10a9b20/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79e402b869f270140afa5e2b0e2ac100585358d812fe3dd093d424f7a72964e0", size = 214966, upload-time = "2026-07-06T15:27:17.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9d/4b19432d406179a40f924691906ee5b15ac664b408971c973295192444ea/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2970b9f7ab69ec3a0423ec6b6ac718e79fbf4a282c0bc103ef88c1ef50dfa15a", size = 231699, upload-time = "2026-07-06T15:27:19.131Z" },
+    { url = "https://files.pythonhosted.org/packages/be/41/bdbdf71e8c3ccff10ef3cc2bb9467a7fdb3dc94b9a406d1a3c44afd39632/charset_normalizer-3.4.8-cp314-cp314t-win32.whl", hash = "sha256:458c2972a78043b7261c9726670029f15f722e70669bcbe961153a01968f589f", size = 155333, upload-time = "2026-07-06T15:27:20.681Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f8/e05c69323bd50091ec39f5f885385b884624b0131a6885a0c83a6217ba7a/charset_normalizer-3.4.8-cp314-cp314t-win_amd64.whl", hash = "sha256:0c926329a1df7cd56d7d8349fe354460d20aefd2e394c9e159e479d018b2b359", size = 167378, upload-time = "2026-07-06T15:27:22.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/04/cbaf1a2f5e2bbf70760e774380cbf052b10849fc35e770905df31af5cf00/charset_normalizer-3.4.8-cp314-cp314t-win_arm64.whl", hash = "sha256:2232baea80a2b01783679fed4e625ccdb19a974f44c9cf0fba21a777a4c8179c", size = 157782, upload-time = "2026-07-06T15:27:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/23/52/d5bee5b6ea81882d549b566d2545b044bbcbc33fe5fbe001008a7e745a21/charset_normalizer-3.4.8-py3-none-any.whl", hash = "sha256:b7c1fb310df524e01fbe84d43b7f95aa4f808f8eaa0dafc185f64ba395e37d54", size = 64279, upload-time = "2026-07-06T15:27:57.043Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "research-skills"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "pymdown-extensions" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0" },
+    { name = "pymdown-extensions", specifier = ">=10.10.0" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]


### PR DESCRIPTION
## Summary

- New MkDocs (Material) documentation site: getting started, architecture, one narrative page per plugin, contributing/versioning reference
- Tooling matches the biosigio repo's setup, minus mkdocstrings/mike/pip-install-e (this repo has no installable Python package): root `pyproject.toml` marks the project non-packaged with a `docs` dependency group, synced via `uv sync --group docs`
- 24 workflow-diagram SVGs reused (byte-identical copies, verified) from the `agentic-research-course` repo, which teaches this exact marketplace week by week
- New `.github/workflows/docs.yml` builds on every docs-touching push/PR and deploys to `gh-pages` on push to `main`
- README gets a tip pointing at the free course: https://courses.osc.earth/agentic-research/
- `docs/contributing.md` documents the plugin-page template and diagram conventions so future plugin/skill additions follow the same shape

Closes #85.

## Test plan

- [x] `uv sync --group docs && uv run mkdocs build --strict` — zero warnings
- [x] Verified all 24 copied SVGs are byte-identical to source and well-formed XML
- [x] Spot-checked rendered HTML: images resolve, tip admonition renders
- [x] `uv run --with pytest --with lxml --with svgelements --with shapely pytest tests/ -q` — 67 passed
- [x] `typos` clean on new content
- [ ] GitHub Pages enablement (repo settings, post-merge, needs separate confirmation)